### PR TITLE
pstsdk::bytes_to_string UTF-8 conversion compatibility

### DIFF
--- a/pstsdk/util/util.h
+++ b/pstsdk/util/util.h
@@ -14,12 +14,16 @@
 #include <cstdlib>
 #include <time.h>
 #include <memory>
-#include <string>
 #include <vector>
 #include <boost/utility.hpp>
 
 #include "pstsdk/util/errors.h"
 #include "pstsdk/util/primitives.h"
+
+#if defined(_WIN32) || defined(__MINGW32__)
+#define NOMINMAX
+#include <windows.h>
+#endif
 
 namespace pstsdk
 {
@@ -250,15 +254,15 @@ inline std::vector<pstsdk::byte> pstsdk::wstring_to_bytes(const std::wstring &ws
     return std::vector<byte>(begin, begin + wstr.size()*sizeof(wchar_t));
 }
 
-// Assume UCS-2LE
+// Assume UCS-2LE, use WideCharToMultiByte to support pre Win 10
 inline std::string pstsdk::bytes_to_string(const std::vector<byte> &bytes)
 {
     // Do the wstr cast and use c_str to avoid any issues stemming from null terminator
     std::wstring ws = bytes_to_wstring(bytes);
-    size_t utf8_sz = wcstombs(NULL, ws.c_str(),  0);
+    size_t utf8_sz = WideCharToMultiByte(CP_UTF8, 0, ws.c_str(), ws.size(), NULL, 0, NULL, NULL);
 
     std::vector<char> utf8_str(utf8_sz);
-    size_t copied = wcstombs(&utf8_str.data()[0], ws.c_str(), utf8_str.size());
+    size_t copied = WideCharToMultiByte(CP_UTF8, 0, ws.c_str(), ws.size(), &utf8_str.data()[0], utf8_sz, NULL, NULL);
 
     if (copied != utf8_sz)
         throw std::runtime_error("Expected to copy " + std::to_string(utf8_sz) + " bytes but copied " + std::to_string(copied));

--- a/pstsdk/util/util.h
+++ b/pstsdk/util/util.h
@@ -14,6 +14,7 @@
 #include <cstdlib>
 #include <time.h>
 #include <memory>
+#include <string>
 #include <vector>
 #include <boost/utility.hpp>
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setlocale-wsetlocale?view=msvc-170#utf-8-support

> Starting in Windows 10 version 1803 (10.0.17134.0), the Universal C Runtime supports using a UTF-8 code page. The change means that char strings passed to C runtime functions can expect strings in the UTF-8 encoding. To enable UTF-8 mode, use ".UTF8" as the code page when using setlocale. For example, setlocale(LC_ALL, ".UTF8") uses the current default Windows ANSI code page (ACP) for the locale and UTF-8 for the code page.

This should work as far back as Win2k