### PR TITLE
in place deletion and free space wipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ compile:
 
 .PHONY: test
 test: compile
-	ninja -C build test
+	CTEST_OUTPUT_ON_FAILURE=1 ninja -C build test

--- a/pstsdk/disk/disk.h
+++ b/pstsdk/disk/disk.h
@@ -108,6 +108,20 @@ enum crypt_method
 //! \tparam T \ref ulonglong for a unicode store, \ref ulong for an ANSI store
 //! \sa [MS-PST] 2.2.2.5
 //! \ingroup disk_headerrelated
+//! \brief Values for \ref root::fAMapValid
+//!
+//! A store marked \ref invalid_amap has its allocation maps rebuilt from the BBT
+//! by the next client to open it, which is how an in place edit can free space
+//! without maintaining the AMaps itself.
+//! \sa [MS-PST] 2.2.2.5/fAMapValid
+//! \ingroup disk_headerrelated
+enum amap_validity
+{
+    invalid_amap = 0, //!< The AMaps are stale and must be rebuilt before use
+    valid_amap1 = 1,  //!< \deprecated Valid, written by pre Outlook 2007 SP2
+    valid_amap2 = 2   //!< Valid
+};
+
 template<typename T>
 struct root
 {
@@ -795,6 +809,15 @@ struct nbt_leaf_entry
 static_assert(sizeof(nbt_leaf_entry<ulong>) == 16, "nbt_leaf_entry<ulong> incorrect size");
 static_assert(sizeof(nbt_leaf_entry<ulonglong>) == 32, "nbt_leaf_entry<ulonglong> incorrect size");
 //! \endcond
+
+//! \brief The value of \ref bbt_leaf_entry::ref_count for an unreferenced block
+//!
+//! The count is the number of references plus one, so a block with exactly one
+//! owner reads as 2. Confirmed against every block of every store under test/,
+//! ANSI and Unicode: nothing referenced once ever reads anything but 2.
+//! \sa [MS-PST] 2.2.2.7.7.3
+//! \ingroup disk_pagerelated
+const ushort block_unreferenced = 1;
 
 //! \brief BBT Leaf Entry
 //!

--- a/pstsdk/disk/disk.h
+++ b/pstsdk/disk/disk.h
@@ -813,8 +813,7 @@ static_assert(sizeof(nbt_leaf_entry<ulonglong>) == 32, "nbt_leaf_entry<ulonglong
 //! \brief The value of \ref bbt_leaf_entry::ref_count for an unreferenced block
 //!
 //! The count is the number of references plus one, so a block with exactly one
-//! owner reads as 2. Confirmed against every block of every store under test/,
-//! ANSI and Unicode: nothing referenced once ever reads anything but 2.
+//! owner reads as 2.
 //! \sa [MS-PST] 2.2.2.7.7.3
 //! \ingroup disk_pagerelated
 const ushort block_unreferenced = 1;

--- a/pstsdk/ltp.h
+++ b/pstsdk/ltp.h
@@ -6,6 +6,7 @@
 #include "pstsdk/ltp/object.h"
 #include "pstsdk/ltp/propbag.h"
 #include "pstsdk/ltp/table.h"
+#include "pstsdk/ltp/writer.h"
 #include "pstsdk/ltp/nameid.h"
 
 #endif

--- a/pstsdk/ltp/writer.h
+++ b/pstsdk/ltp/writer.h
@@ -229,6 +229,7 @@ inline bool cell_is_hnid(ushort type)
     case prop_type_wstring:
     case prop_type_binary:
     case prop_type_object:
+    case prop_type_guid:
         return true;
     default:
         return (type & 0x1000) != 0;
@@ -236,7 +237,8 @@ inline bool cell_is_hnid(ushort type)
 }
 
 inline void row_heap_cells(const std::vector<byte>& header, const byte* row,
-                           size_t exists_at, std::vector<heap_id>& cells)
+                           size_t exists_at, std::vector<heap_id>& cells,
+                           std::vector<node_id>* subnodes = 0)
 {
     const disk::tc_header* tc = reinterpret_cast<const disk::tc_header*>(&header[0]);
 
@@ -253,10 +255,13 @@ inline void row_heap_cells(const std::vector<byte>& header, const byte* row,
         heapnode_id hnid;
         memcpy(&hnid, row + column.offset, sizeof(hnid));
 
-        // a subnode cell would need the subnode removed too, which is a
-        // different primitive; only heap allocations are ours to free here
-        if(hnid != 0 && is_heap_id(hnid))
+        if(hnid == 0)
+            continue;
+
+        if(is_heap_id(hnid))
             cells.push_back(hnid);
+        else if(subnodes)
+            subnodes->push_back(hnid);
     }
 }
 
@@ -374,6 +379,17 @@ private:
     size_t m_rows_per_block;
     std::vector<block_id> m_blocks;
 };
+
+//! A row's oversized cells live in the table's own subnode tree, so they outlive
+//! the row unless they are taken out with it.
+template<typename T>
+inline void free_row_subnodes(db_writer<T>& writer,
+                              const typename db_writer<T>::data_ref& table,
+                              const std::vector<node_id>& subnodes)
+{
+    for(size_t i = 0; i < subnodes.size(); ++i)
+        writer.subnode_remove(table.sub, subnodes[i]);
+}
 
 //! \brief How a particular BTH lays its entries out on disk
 //!
@@ -622,24 +638,41 @@ inline void pstsdk::tc_remove_row(db_writer<T>& writer,
                                               layout.value_size);
     const size_t last = count - 1;
 
-    // Cells wider than the row point at heap allocations. Nothing references them
-    // once the row is gone, and they hold the cached subject and sender in clear
-    // text, so they are freed rather than merely orphaned.
+    if(target > last)
+        throw database_corrupt("row index points past the matrix");
+
+    // Cells wider than the row point at heap allocations or subnodes. Nothing
+    // references them once the row is gone, and they hold the cached subject and
+    // sender in clear text, so they are freed rather than merely orphaned.
     std::vector<byte> doomed_row = matrix.read_row(target);
     std::vector<heap_id> doomed_cells;
-    detail::row_heap_cells(raw, &doomed_row[0], exists_at, doomed_cells);
+    std::vector<node_id> doomed_subnodes;
+    detail::row_heap_cells(raw, &doomed_row[0], exists_at, doomed_cells, &doomed_subnodes);
+
+    // the index and the matrix have to agree about which row this is
+    row_id at_target;
+    memcpy(&at_target, &doomed_row[0], sizeof(row_id));
+    if(at_target != id)
+        throw database_corrupt("row index and row matrix disagree");
+
+    // Resolve the moved row's index entry before the swap, so a key that is not
+    // there is reported while the table is still untouched.
+    std::vector<byte> moving;
+    std::vector<heap_id> moved_path;
+    std::vector<uint> moved_indices;
+
+    if(target != last)
+    {
+        moving = matrix.read_row(last);
+        row_id moved;
+        memcpy(&moved, &moving[0], sizeof(row_id));
+        detail::bth_descend(heap, layout, moved, moved_path, moved_indices);
+    }
 
     if(target != last)
     {
         // the moved row keeps its id, so the index has to learn its new position
-        std::vector<byte> moving = matrix.read_row(last);
-        row_id moved;
-        memcpy(&moved, &moving[0], sizeof(row_id));
         matrix.write_row(target, moving);
-
-        std::vector<heap_id> moved_path;
-        std::vector<uint> moved_indices;
-        detail::bth_descend(heap, layout, moved, moved_path, moved_indices);
 
         std::vector<byte> moved_leaf = heap.read_alloc(moved_path.back());
         detail::bth_write_at(moved_leaf, layout.value_offset(moved_indices.back()),
@@ -663,11 +696,14 @@ inline void pstsdk::tc_remove_row(db_writer<T>& writer,
             if(std::find(kept.begin(), kept.end(), doomed_cells[i]) == kept.end())
                 heap.shrink_alloc(doomed_cells[i], 0);
 
+        detail::free_row_subnodes(writer, table, doomed_subnodes);
         return;
     }
 
     for(size_t i = 0; i < doomed_cells.size(); ++i)
         heap.shrink_alloc(doomed_cells[i], 0);
+
+    detail::free_row_subnodes(writer, table, doomed_subnodes);
 
     // an emptied table carries neither a matrix nor a row index root on disk,
     // which is what one that was never populated looks like
@@ -676,6 +712,9 @@ inline void pstsdk::tc_remove_row(db_writer<T>& writer,
     std::vector<byte> header_raw = heap.read_alloc(root);
     reinterpret_cast<disk::tc_header*>(&header_raw[0])->row_matrix_id = 0;
     heap.write_alloc(root, header_raw);
+
+    if(is_subnode_id(matrix_id))
+        writer.subnode_remove(table.sub, (node_id)matrix_id);
 }
 //! \endcond
 

--- a/pstsdk/ltp/writer.h
+++ b/pstsdk/ltp/writer.h
@@ -53,17 +53,6 @@ public:
     //! \brief The heap's root allocation, as recorded in its first block
     heap_id root_id();
 
-    std::vector<byte> read_block(uint page) { return m_writer.read_block(m_blocks.at(page)); }
-    void write_block(uint page, const std::vector<byte>& data)
-        { m_writer.write_block(m_blocks.at(page), data); }
-
-    //! \brief Locate an allocation within its heap block
-    //! \param[in] id The allocation to resolve
-    //! \param[out] page The heap block holding it
-    //! \param[out] offset Its offset within that block
-    //! \param[out] size Its length in bytes
-    void locate(heap_id id, uint& page, size_t& offset, size_t& size);
-
     //! \brief Read an allocation's bytes
     std::vector<byte> read_alloc(heap_id id);
 
@@ -80,6 +69,11 @@ public:
     void shrink_alloc(heap_id id, size_t size);
 
 private:
+    std::vector<byte> read_block(uint page) { return m_writer.read_block(m_blocks.at(page)); }
+    void write_block(uint page, const std::vector<byte>& data)
+        { m_writer.write_block(m_blocks.at(page), data); }
+    void locate(heap_id id, uint& page, size_t& offset, size_t& size);
+
     db_writer<T>& m_writer;
     typename db_writer<T>::data_ref m_ref;
     std::vector<block_id> m_blocks;
@@ -89,7 +83,7 @@ private:
 //!
 //! A \ref disk::prop_entry carries values of four bytes or fewer in its id field
 //! rather than pointing at them, so this is a same size edit. Used for the folder
-//! counts and the message flags that have to track a delete.
+//! counts and \ref PR_HASATTACH.
 //! \throws key_not_found<prop_id> if the property is not present
 //! \ingroup ltp_pcrelated
 template<typename T>
@@ -205,7 +199,6 @@ inline void pstsdk::heap_writer<T>::shrink_alloc(heap_id id, size_t size)
 
     const size_t used = map->allocs[map->num_allocs];
 
-    // slide everything above the allocation down over the bytes being given up
     memmove(&block[offset + size], &block[offset + current], used - offset - current);
     memset(&block[used - freed], 0, freed);
 
@@ -242,7 +235,6 @@ inline bool cell_is_hnid(ushort type)
     }
 }
 
-//! The heap allocations a row's cells point at, skipping columns it does not have
 inline void row_heap_cells(const std::vector<byte>& header, const byte* row,
                            size_t exists_at, std::vector<heap_id>& cells)
 {
@@ -273,8 +265,7 @@ inline void row_heap_cells(const std::vector<byte>& header, const byte* row,
 //! A small table holds its rows in a heap allocation. Once they outgrow one,
 //! which happens at a few dozen rows, the client moves them into a subnode with
 //! its own blocks. Both are the same fixed width array to a caller; only the
-//! shrink differs, and that is the whole reason the subnode case needs the block
-//! level primitives rather than the heap ones.
+//! shrink differs.
 template<typename T>
 class matrix_writer
 {
@@ -318,7 +309,7 @@ public:
         store(index, block);
     }
 
-    //! \returns true once the matrix holds no rows at all
+    // true once the matrix is empty
     bool drop_last_row()
     {
         if(m_inline)
@@ -434,7 +425,6 @@ inline void bth_write_at(std::vector<byte>& alloc, size_t offset, size_t width, 
     memcpy(&alloc[offset], &value, width);
 }
 
-//! Walk a BTH to the allocation holding an exact key, recording the path
 template<typename T>
 inline void bth_descend(heap_writer<T>& heap, const bth_layout& layout, ulong key,
                         std::vector<heap_id>& path, std::vector<uint>& indices)

--- a/pstsdk/ltp/writer.h
+++ b/pstsdk/ltp/writer.h
@@ -40,7 +40,15 @@ class heap_writer
 {
 public:
     heap_writer(db_writer<T>& writer, node_id nid)
-        : m_writer(writer), m_blocks(writer.node_external_blocks(nid)) { }
+        : m_writer(writer), m_ref(writer.node_ref(nid)),
+          m_blocks(writer.external_blocks(m_ref.data)) { }
+
+    //! A heap carried by a subnode, which is where an attachment table lives
+    heap_writer(db_writer<T>& writer, const typename db_writer<T>::data_ref& ref)
+        : m_writer(writer), m_ref(ref), m_blocks(writer.external_blocks(ref.data)) { }
+
+    //! \brief Where this heap's owner keeps its data and its own subnodes
+    const typename db_writer<T>::data_ref& ref() const { return m_ref; }
 
     //! \brief The heap's root allocation, as recorded in its first block
     heap_id root_id();
@@ -73,6 +81,7 @@ public:
 
 private:
     db_writer<T>& m_writer;
+    typename db_writer<T>::data_ref m_ref;
     std::vector<block_id> m_blocks;
 };
 
@@ -98,6 +107,14 @@ void pc_set_inline(db_writer<T>& writer, node_id nid, prop_id id, ulong value);
 //! \ingroup ltp_tcrelated
 template<typename T>
 void tc_remove_row(db_writer<T>& writer, node_id nid, row_id id);
+
+//! \brief Remove a row from a table context carried by a subnode
+//!
+//! A message's attachment and recipient tables live this way.
+//! \throws key_not_found<row_id> if the row is not in the table
+//! \ingroup ltp_tcrelated
+template<typename T>
+void tc_remove_row(db_writer<T>& writer, const typename db_writer<T>::data_ref& table, row_id id);
 
 //! \endcond
 
@@ -262,15 +279,15 @@ template<typename T>
 class matrix_writer
 {
 public:
-    matrix_writer(db_writer<T>& writer, heap_writer<T>& heap, node_id table,
-                  heapnode_id matrix, size_t cb_per_row)
-        : m_writer(writer), m_heap(heap), m_table(table), m_matrix(matrix),
+    matrix_writer(db_writer<T>& writer, heap_writer<T>& heap, heapnode_id matrix,
+                  size_t cb_per_row)
+        : m_writer(writer), m_heap(heap), m_matrix(matrix),
           m_cb_per_row(cb_per_row), m_inline(!is_subnode_id(matrix)), m_rows_per_block(0)
     {
         if(m_inline)
             return;
 
-        m_blocks = writer.external_blocks(writer.subnode_data(table, (node_id)matrix));
+        m_blocks = writer.external_blocks(root());
         if(m_blocks.empty())
             throw database_corrupt("row matrix subnode has no blocks");
 
@@ -327,7 +344,11 @@ public:
     }
 
 private:
-    block_id root() { return m_writer.subnode_data(m_table, (node_id)m_matrix); }
+    // the matrix hangs off the table's own subnode tree, not the store's
+    block_id root()
+    {
+        return m_writer.subnode_ref(m_heap.ref().sub, (node_id)m_matrix).data;
+    }
 
     size_t last_block_rows()
     {
@@ -356,7 +377,6 @@ private:
 
     db_writer<T>& m_writer;
     heap_writer<T>& m_heap;
-    node_id m_table;
     heapnode_id m_matrix;
     size_t m_cb_per_row;
     bool m_inline;
@@ -548,7 +568,14 @@ inline void pstsdk::pc_set_inline(db_writer<T>& writer, node_id nid, prop_id id,
 template<typename T>
 inline void pstsdk::tc_remove_row(db_writer<T>& writer, node_id nid, row_id id)
 {
-    heap_writer<T> heap(writer, nid);
+    tc_remove_row(writer, writer.node_ref(nid), id);
+}
+
+template<typename T>
+inline void pstsdk::tc_remove_row(db_writer<T>& writer,
+                                  const typename db_writer<T>::data_ref& table, row_id id)
+{
+    heap_writer<T> heap(writer, table);
     const heap_id root = heap.root_id();
 
     std::vector<byte> raw = heap.read_alloc(root);
@@ -566,7 +593,7 @@ inline void pstsdk::tc_remove_row(db_writer<T>& writer, node_id nid, row_id id)
         throw key_not_found<row_id>(id);
 
     detail::bth_layout layout = detail::bth_read_layout(heap, row_btree);
-    detail::matrix_writer<T> matrix(writer, heap, nid, matrix_id, cb_per_row);
+    detail::matrix_writer<T> matrix(writer, heap, matrix_id, cb_per_row);
 
     const size_t count = matrix.rows();
     if(count == 0)

--- a/pstsdk/ltp/writer.h
+++ b/pstsdk/ltp/writer.h
@@ -392,6 +392,7 @@ private:
 //! 6 bytes at a time.
 struct bth_layout
 {
+    heap_id header;
     size_t key_size;
     size_t value_size;
     byte levels;
@@ -412,6 +413,7 @@ inline bth_layout bth_read_layout(heap_writer<T>& heap, heap_id bth_root)
         throw database_corrupt("invalid BTH signature");
 
     bth_layout layout;
+    layout.header = bth_root;
     layout.key_size = header->key_size;
     layout.value_size = header->entry_size;
     layout.levels = header->num_levels;
@@ -474,6 +476,19 @@ inline void bth_descend(heap_writer<T>& heap, const bth_layout& layout, ulong ke
     throw key_not_found<ulong>(key);
 }
 
+//! An empty tree has to say so in its header. Leaving num_levels alone while the
+//! root goes to zero makes bth_node::open_nonleaf index an empty allocation,
+//! which only bites once a table is big enough to need more than one level.
+template<typename T>
+inline void bth_empty(heap_writer<T>& heap, const bth_layout& layout)
+{
+    std::vector<byte> raw = heap.read_alloc(layout.header);
+    disk::bth_header* header = reinterpret_cast<disk::bth_header*>(&raw[0]);
+    header->root = 0;
+    header->num_levels = 0;
+    heap.write_alloc(layout.header, raw);
+}
+
 //! Drop one leaf entry, fixing the ancestors that named the leaf by its first key
 template<typename T>
 inline void bth_remove_key(heap_writer<T>& heap, const bth_layout& layout, ulong key)
@@ -493,6 +508,12 @@ inline void bth_remove_key(heap_writer<T>& heap, const bth_layout& layout, ulong
 
     heap.write_alloc(path.back(), alloc);
     heap.shrink_alloc(path.back(), (count - 1) * stride);
+
+    if(count == 1 && path.size() == 1)
+    {
+        bth_empty(heap, layout);
+        return;
+    }
 
     if(count > 1)
     {
@@ -533,6 +554,9 @@ inline void bth_remove_key(heap_writer<T>& heap, const bth_layout& layout, ulong
 
         if(parent_count > 1)
             return;
+
+        if(depth == 0)
+            bth_empty(heap, layout);
     }
 }
 
@@ -657,9 +681,7 @@ inline void pstsdk::tc_remove_row(db_writer<T>& writer,
 
     // an emptied table carries neither a matrix nor a row index root on disk,
     // which is what one that was never populated looks like
-    std::vector<byte> bth_raw = heap.read_alloc(row_btree);
-    reinterpret_cast<disk::bth_header*>(&bth_raw[0])->root = 0;
-    heap.write_alloc(row_btree, bth_raw);
+    detail::bth_empty(heap, layout);
 
     std::vector<byte> header_raw = heap.read_alloc(root);
     reinterpret_cast<disk::tc_header*>(&header_raw[0])->row_matrix_id = 0;

--- a/pstsdk/ltp/writer.h
+++ b/pstsdk/ltp/writer.h
@@ -251,6 +251,119 @@ inline void row_heap_cells(const std::vector<byte>& header, const byte* row,
     }
 }
 
+//! \brief Reads and shrinks a table's row matrix wherever the table keeps it
+//!
+//! A small table holds its rows in a heap allocation. Once they outgrow one,
+//! which happens at a few dozen rows, the client moves them into a subnode with
+//! its own blocks. Both are the same fixed width array to a caller; only the
+//! shrink differs, and that is the whole reason the subnode case needs the block
+//! level primitives rather than the heap ones.
+template<typename T>
+class matrix_writer
+{
+public:
+    matrix_writer(db_writer<T>& writer, heap_writer<T>& heap, node_id table,
+                  heapnode_id matrix, size_t cb_per_row)
+        : m_writer(writer), m_heap(heap), m_table(table), m_matrix(matrix),
+          m_cb_per_row(cb_per_row), m_inline(!is_subnode_id(matrix)), m_rows_per_block(0)
+    {
+        if(m_inline)
+            return;
+
+        m_blocks = writer.external_blocks(writer.subnode_data(table, (node_id)matrix));
+        if(m_blocks.empty())
+            throw database_corrupt("row matrix subnode has no blocks");
+
+        m_rows_per_block = writer.read_block(m_blocks[0]).size() / cb_per_row;
+        if(m_rows_per_block == 0)
+            throw database_corrupt("row matrix block smaller than one row");
+    }
+
+    size_t rows()
+    {
+        if(m_inline)
+            return m_heap.read_alloc(m_matrix).size() / m_cb_per_row;
+
+        return (m_blocks.size() - 1) * m_rows_per_block + last_block_rows();
+    }
+
+    std::vector<byte> read_row(size_t index)
+    {
+        std::vector<byte> block = load(index);
+        const size_t at = offset_of(index);
+        return std::vector<byte>(block.begin() + at, block.begin() + at + m_cb_per_row);
+    }
+
+    void write_row(size_t index, const std::vector<byte>& row)
+    {
+        std::vector<byte> block = load(index);
+        memcpy(&block[offset_of(index)], &row[0], m_cb_per_row);
+        store(index, block);
+    }
+
+    //! \returns true once the matrix holds no rows at all
+    bool drop_last_row()
+    {
+        if(m_inline)
+        {
+            const size_t left = rows() - 1;
+            m_heap.shrink_alloc(m_matrix, left * m_cb_per_row);
+            return left == 0;
+        }
+
+        const size_t left_in_block = last_block_rows() - 1;
+        const size_t size = m_writer.read_block(m_blocks.back()).size();
+        const size_t shrunk = left_in_block ? size - m_cb_per_row : 0;
+
+        if(!m_writer.shrink_data_tail(root(), shrunk))
+        {
+            if(shrunk == 0)
+                m_blocks.pop_back();
+            return m_blocks.empty();
+        }
+
+        m_blocks.clear();
+        return true;
+    }
+
+private:
+    block_id root() { return m_writer.subnode_data(m_table, (node_id)m_matrix); }
+
+    size_t last_block_rows()
+    {
+        return m_writer.read_block(m_blocks.back()).size() / m_cb_per_row;
+    }
+
+    size_t block_of(size_t index) const { return m_inline ? 0 : index / m_rows_per_block; }
+    size_t offset_of(size_t index) const
+    {
+        return (m_inline ? index : index % m_rows_per_block) * m_cb_per_row;
+    }
+
+    std::vector<byte> load(size_t index)
+    {
+        return m_inline ? m_heap.read_alloc(m_matrix)
+                        : m_writer.read_block(m_blocks[block_of(index)]);
+    }
+
+    void store(size_t index, const std::vector<byte>& block)
+    {
+        if(m_inline)
+            m_heap.write_alloc(m_matrix, block);
+        else
+            m_writer.write_block(m_blocks[block_of(index)], block);
+    }
+
+    db_writer<T>& m_writer;
+    heap_writer<T>& m_heap;
+    node_id m_table;
+    heapnode_id m_matrix;
+    size_t m_cb_per_row;
+    bool m_inline;
+    size_t m_rows_per_block;
+    std::vector<block_id> m_blocks;
+};
+
 //! \brief How a particular BTH lays its entries out on disk
 //!
 //! The strides come from the BTH header rather than from sizeof, because the
@@ -445,23 +558,17 @@ inline void pstsdk::tc_remove_row(db_writer<T>& writer, node_id nid, row_id id)
         throw database_corrupt("not a table context");
 
     const size_t cb_per_row = header->size_offsets[disk::tc_offsets_bitmap];
+    const size_t exists_at = header->size_offsets[disk::tc_offsets_one];
     const heap_id row_btree = header->row_btree_id;
-    const heapnode_id matrix = header->row_matrix_id;
+    const heapnode_id matrix_id = header->row_matrix_id;
 
-    if(matrix == 0)
+    if(matrix_id == 0 || cb_per_row == 0)
         throw key_not_found<row_id>(id);
 
-    // Every table in every store under test/ keeps its matrix inline. A folder
-    // big enough to outgrow a heap allocation moves it into a subnode, which
-    // needs a block level shrink instead and is not handled yet.
-    if(is_subnode_id(matrix))
-        throw not_implemented("row matrix held in a subnode");
-
     detail::bth_layout layout = detail::bth_read_layout(heap, row_btree);
+    detail::matrix_writer<T> matrix(writer, heap, nid, matrix_id, cb_per_row);
 
-    std::vector<byte> rows = heap.read_alloc(matrix);
-    const size_t count = cb_per_row ? rows.size() / cb_per_row : 0;
-
+    const size_t count = matrix.rows();
     if(count == 0)
         throw key_not_found<row_id>(id);
 
@@ -474,16 +581,20 @@ inline void pstsdk::tc_remove_row(db_writer<T>& writer, node_id nid, row_id id)
                                               layout.value_size);
     const size_t last = count - 1;
 
-    std::vector<byte> doomed_row(rows.begin() + target * cb_per_row,
-                                 rows.begin() + (target + 1) * cb_per_row);
+    // Cells wider than the row point at heap allocations. Nothing references them
+    // once the row is gone, and they hold the cached subject and sender in clear
+    // text, so they are freed rather than merely orphaned.
+    std::vector<byte> doomed_row = matrix.read_row(target);
+    std::vector<heap_id> doomed_cells;
+    detail::row_heap_cells(raw, &doomed_row[0], exists_at, doomed_cells);
 
     if(target != last)
     {
         // the moved row keeps its id, so the index has to learn its new position
+        std::vector<byte> moving = matrix.read_row(last);
         row_id moved;
-        memcpy(&moved, &rows[last * cb_per_row], sizeof(row_id));
-        memcpy(&rows[target * cb_per_row], &rows[last * cb_per_row], cb_per_row);
-        heap.write_alloc(matrix, rows);
+        memcpy(&moved, &moving[0], sizeof(row_id));
+        matrix.write_row(target, moving);
 
         std::vector<heap_id> moved_path;
         std::vector<uint> moved_indices;
@@ -495,38 +606,27 @@ inline void pstsdk::tc_remove_row(db_writer<T>& writer, node_id nid, row_id id)
         heap.write_alloc(moved_path.back(), moved_leaf);
     }
 
-    // Cells wider than the row point at heap allocations. Nothing will reference
-    // them once the row is gone, and they hold the cached subject and sender in
-    // clear text, so they have to be freed rather than merely orphaned.
-    std::vector<heap_id> doomed_cells;
-    detail::row_heap_cells(raw, &doomed_row[0], header->size_offsets[disk::tc_offsets_one],
-                           doomed_cells);
-
-    heap.shrink_alloc(matrix, last * cb_per_row);
+    const bool emptied = matrix.drop_last_row();
     detail::bth_remove_key(heap, layout, id);
 
-    if(last > 0 && !doomed_cells.empty())
+    if(!emptied)
     {
-        // keep anything a surviving row still points at
-        std::vector<byte> survivors = heap.read_alloc(matrix);
         std::vector<heap_id> kept;
-
         for(size_t r = 0; r < last; ++r)
-            detail::row_heap_cells(raw, &survivors[r * cb_per_row],
-                                   header->size_offsets[disk::tc_offsets_one], kept);
+        {
+            std::vector<byte> survivor = matrix.read_row(r);
+            detail::row_heap_cells(raw, &survivor[0], exists_at, kept);
+        }
 
         for(size_t i = 0; i < doomed_cells.size(); ++i)
             if(std::find(kept.begin(), kept.end(), doomed_cells[i]) == kept.end())
                 heap.shrink_alloc(doomed_cells[i], 0);
-    }
-    else
-    {
-        for(size_t i = 0; i < doomed_cells.size(); ++i)
-            heap.shrink_alloc(doomed_cells[i], 0);
+
+        return;
     }
 
-    if(last > 0)
-        return;
+    for(size_t i = 0; i < doomed_cells.size(); ++i)
+        heap.shrink_alloc(doomed_cells[i], 0);
 
     // an emptied table carries neither a matrix nor a row index root on disk,
     // which is what one that was never populated looks like

--- a/pstsdk/ltp/writer.h
+++ b/pstsdk/ltp/writer.h
@@ -15,6 +15,7 @@
 #ifndef PSTSDK_LTP_WRITER_H
 #define PSTSDK_LTP_WRITER_H
 
+#include <algorithm>
 #include <cstring>
 #include <vector>
 
@@ -204,6 +205,51 @@ namespace pstsdk
 {
 namespace detail
 {
+
+//! \brief Whether a column's value lives outside the row rather than inside it
+//!
+//! Anything variable length or multi valued is stored as a heap id in the cell,
+//! so the row is only a pointer to it.
+//! \sa [MS-PST] 2.3.4.2
+inline bool cell_is_hnid(ushort type)
+{
+    switch(type)
+    {
+    case prop_type_string:
+    case prop_type_wstring:
+    case prop_type_binary:
+    case prop_type_object:
+        return true;
+    default:
+        return (type & 0x1000) != 0;
+    }
+}
+
+//! The heap allocations a row's cells point at, skipping columns it does not have
+inline void row_heap_cells(const std::vector<byte>& header, const byte* row,
+                           size_t exists_at, std::vector<heap_id>& cells)
+{
+    const disk::tc_header* tc = reinterpret_cast<const disk::tc_header*>(&header[0]);
+
+    for(byte i = 0; i < tc->num_columns; ++i)
+    {
+        const disk::column_description& column = tc->columns[i];
+
+        if(column.size != sizeof(heapnode_id) || !cell_is_hnid(column.type))
+            continue;
+
+        if(!test_bit(row + exists_at, column.bit_offset))
+            continue;
+
+        heapnode_id hnid;
+        memcpy(&hnid, row + column.offset, sizeof(hnid));
+
+        // a subnode cell would need the subnode removed too, which is a
+        // different primitive; only heap allocations are ours to free here
+        if(hnid != 0 && is_heap_id(hnid))
+            cells.push_back(hnid);
+    }
+}
 
 //! \brief How a particular BTH lays its entries out on disk
 //!
@@ -428,6 +474,9 @@ inline void pstsdk::tc_remove_row(db_writer<T>& writer, node_id nid, row_id id)
                                               layout.value_size);
     const size_t last = count - 1;
 
+    std::vector<byte> doomed_row(rows.begin() + target * cb_per_row,
+                                 rows.begin() + (target + 1) * cb_per_row);
+
     if(target != last)
     {
         // the moved row keeps its id, so the index has to learn its new position
@@ -446,8 +495,35 @@ inline void pstsdk::tc_remove_row(db_writer<T>& writer, node_id nid, row_id id)
         heap.write_alloc(moved_path.back(), moved_leaf);
     }
 
+    // Cells wider than the row point at heap allocations. Nothing will reference
+    // them once the row is gone, and they hold the cached subject and sender in
+    // clear text, so they have to be freed rather than merely orphaned.
+    std::vector<heap_id> doomed_cells;
+    detail::row_heap_cells(raw, &doomed_row[0], header->size_offsets[disk::tc_offsets_one],
+                           doomed_cells);
+
     heap.shrink_alloc(matrix, last * cb_per_row);
     detail::bth_remove_key(heap, layout, id);
+
+    if(last > 0 && !doomed_cells.empty())
+    {
+        // keep anything a surviving row still points at
+        std::vector<byte> survivors = heap.read_alloc(matrix);
+        std::vector<heap_id> kept;
+
+        for(size_t r = 0; r < last; ++r)
+            detail::row_heap_cells(raw, &survivors[r * cb_per_row],
+                                   header->size_offsets[disk::tc_offsets_one], kept);
+
+        for(size_t i = 0; i < doomed_cells.size(); ++i)
+            if(std::find(kept.begin(), kept.end(), doomed_cells[i]) == kept.end())
+                heap.shrink_alloc(doomed_cells[i], 0);
+    }
+    else
+    {
+        for(size_t i = 0; i < doomed_cells.size(); ++i)
+            heap.shrink_alloc(doomed_cells[i], 0);
+    }
 
     if(last > 0)
         return;

--- a/pstsdk/ltp/writer.h
+++ b/pstsdk/ltp/writer.h
@@ -1,0 +1,467 @@
+//! \file
+//! \brief In place edits of heaps, BTHs, property contexts and table contexts
+//!
+//! Built on \ref db_writer, so the same rules apply: nothing moves, nothing
+//! grows, and a shared block is refused rather than copied.
+//!
+//! Heap allocations shrink the way [MS-PST] 2.3.1.5 describes, by sliding the
+//! allocations above them down and leaving the freed entry zero length. The
+//! allocation array never shrinks, so every heap id in the block keeps its
+//! meaning. The block itself must not shrink either: \ref heap_impl::size reads
+//! the page map as everything from page_map_offset to the end of the block, so
+//! trimming the block would truncate the map.
+//! \ingroup ltp
+
+#ifndef PSTSDK_LTP_WRITER_H
+#define PSTSDK_LTP_WRITER_H
+
+#include <cstring>
+#include <vector>
+
+#include "pstsdk/util/errors.h"
+#include "pstsdk/util/primitives.h"
+
+#include "pstsdk/ndb/writer.h"
+
+namespace pstsdk
+{
+
+//! \cond write_api
+
+//! \brief Edits the heap carried by a single node
+//!
+//! Resolves heap ids to a block and an offset, and writes whole heap blocks back
+//! through \ref db_writer.
+//! \tparam T ulonglong for a Unicode store, ulong for an ANSI store
+//! \ingroup ltp_heaprelated
+template<typename T>
+class heap_writer
+{
+public:
+    heap_writer(db_writer<T>& writer, node_id nid)
+        : m_writer(writer), m_blocks(writer.node_external_blocks(nid)) { }
+
+    //! \brief The heap's root allocation, as recorded in its first block
+    heap_id root_id();
+
+    std::vector<byte> read_block(uint page) { return m_writer.read_block(m_blocks.at(page)); }
+    void write_block(uint page, const std::vector<byte>& data)
+        { m_writer.write_block(m_blocks.at(page), data); }
+
+    //! \brief Locate an allocation within its heap block
+    //! \param[in] id The allocation to resolve
+    //! \param[out] page The heap block holding it
+    //! \param[out] offset Its offset within that block
+    //! \param[out] size Its length in bytes
+    void locate(heap_id id, uint& page, size_t& offset, size_t& size);
+
+    //! \brief Read an allocation's bytes
+    std::vector<byte> read_alloc(heap_id id);
+
+    //! \brief Overwrite an allocation without changing its length
+    void write_alloc(heap_id id, const std::vector<byte>& data);
+
+    //! \brief Shrink an allocation, sliding everything above it down
+    //!
+    //! Passing zero frees it outright, which is what the format calls a
+    //! zero length allocation rather than a removed one.
+    //! \throws can_not_resize if asked to grow
+    //! \param[in] id The allocation to shrink
+    //! \param[in] size Its new length, at most its current one
+    void shrink_alloc(heap_id id, size_t size);
+
+private:
+    db_writer<T>& m_writer;
+    std::vector<block_id> m_blocks;
+};
+
+//! \brief Overwrite a fixed width property held inline in a property context
+//!
+//! A \ref disk::prop_entry carries values of four bytes or fewer in its id field
+//! rather than pointing at them, so this is a same size edit. Used for the folder
+//! counts and the message flags that have to track a delete.
+//! \throws key_not_found<prop_id> if the property is not present
+//! \ingroup ltp_pcrelated
+template<typename T>
+void pc_set_inline(db_writer<T>& writer, node_id nid, prop_id id, ulong value);
+
+//! \brief Remove a row from a table context
+//!
+//! Copies the last row over the doomed one and drops the matrix by a row, rather
+//! than compacting, so only two row index entries move instead of every entry
+//! above the deletion point. Row order carries no meaning in a table context.
+//! \throws key_not_found<row_id> if the row is not in the table
+//! \param[in] writer The store to edit
+//! \param[in] nid The table's node
+//! \param[in] id The row to remove, which for a folder table is the item's node id
+//! \ingroup ltp_tcrelated
+template<typename T>
+void tc_remove_row(db_writer<T>& writer, node_id nid, row_id id);
+
+//! \endcond
+
+} // end pstsdk namespace
+
+//! \cond write_api
+template<typename T>
+inline pstsdk::heap_id pstsdk::heap_writer<T>::root_id()
+{
+    std::vector<byte> first = read_block(0);
+    const disk::heap_first_header* header =
+        reinterpret_cast<const disk::heap_first_header*>(&first[0]);
+
+    if(header->signature != disk::heap_signature)
+        throw database_corrupt("invalid heap signature");
+
+    return header->root_id;
+}
+
+template<typename T>
+inline void pstsdk::heap_writer<T>::locate(heap_id id, uint& page, size_t& offset, size_t& size)
+{
+    page = get_heap_page(id);
+    const uint index = get_heap_index(id);
+
+    std::vector<byte> block = read_block(page);
+    const disk::heap_page_header* header =
+        reinterpret_cast<const disk::heap_page_header*>(&block[0]);
+    const disk::heap_page_map* map =
+        reinterpret_cast<const disk::heap_page_map*>(&block[header->page_map_offset]);
+
+    if(index >= map->num_allocs)
+        throw std::length_error("heap index past num_allocs");
+
+    offset = map->allocs[index];
+    size = map->allocs[index + 1] - map->allocs[index];
+}
+
+template<typename T>
+inline std::vector<pstsdk::byte> pstsdk::heap_writer<T>::read_alloc(heap_id id)
+{
+    uint page;
+    size_t offset;
+    size_t size;
+    locate(id, page, offset, size);
+
+    std::vector<byte> block = read_block(page);
+    return std::vector<byte>(block.begin() + offset, block.begin() + offset + size);
+}
+
+template<typename T>
+inline void pstsdk::heap_writer<T>::write_alloc(heap_id id, const std::vector<byte>& data)
+{
+    uint page;
+    size_t offset;
+    size_t size;
+    locate(id, page, offset, size);
+
+    if(data.size() != size)
+        throw can_not_resize("write_alloc cannot change an allocation's size");
+
+    std::vector<byte> block = read_block(page);
+    if(size > 0)
+        memcpy(&block[offset], &data[0], size);
+    write_block(page, block);
+}
+
+template<typename T>
+inline void pstsdk::heap_writer<T>::shrink_alloc(heap_id id, size_t size)
+{
+    uint page;
+    size_t offset;
+    size_t current;
+    locate(id, page, offset, current);
+
+    if(size > current)
+        throw can_not_resize("shrink_alloc cannot grow an allocation");
+    if(size == current)
+        return;
+
+    const size_t freed = current - size;
+    const uint index = get_heap_index(id);
+
+    std::vector<byte> block = read_block(page);
+    disk::heap_page_header* header = reinterpret_cast<disk::heap_page_header*>(&block[0]);
+    disk::heap_page_map* map =
+        reinterpret_cast<disk::heap_page_map*>(&block[header->page_map_offset]);
+
+    const size_t used = map->allocs[map->num_allocs];
+
+    // slide everything above the allocation down over the bytes being given up
+    memmove(&block[offset + size], &block[offset + current], used - offset - current);
+    memset(&block[used - freed], 0, freed);
+
+    for(uint i = index + 1; i <= map->num_allocs; ++i)
+        map->allocs[i] = (ushort)(map->allocs[i] - freed);
+
+    if(size == 0)
+        ++map->num_frees;
+
+    write_block(page, block);
+}
+
+namespace pstsdk
+{
+namespace detail
+{
+
+//! \brief How a particular BTH lays its entries out on disk
+//!
+//! The strides come from the BTH header rather than from sizeof, because the
+//! disk structs do not all pack the way the format does. sizeof
+//! bth_leaf_entry<row_id, ushort> is 8, while an ANSI row index really steps
+//! 6 bytes at a time.
+struct bth_layout
+{
+    size_t key_size;
+    size_t value_size;
+    byte levels;
+    heap_id root;
+
+    size_t leaf_stride() const { return key_size + value_size; }
+    size_t nonleaf_stride() const { return key_size + sizeof(heap_id); }
+    size_t value_offset(uint index) const { return index * leaf_stride() + key_size; }
+};
+
+template<typename T>
+inline bth_layout bth_read_layout(heap_writer<T>& heap, heap_id bth_root)
+{
+    std::vector<byte> raw = heap.read_alloc(bth_root);
+    const disk::bth_header* header = reinterpret_cast<const disk::bth_header*>(&raw[0]);
+
+    if(header->bth_signature != disk::heap_sig_bth)
+        throw database_corrupt("invalid BTH signature");
+
+    bth_layout layout;
+    layout.key_size = header->key_size;
+    layout.value_size = header->entry_size;
+    layout.levels = header->num_levels;
+    layout.root = header->root;
+    return layout;
+}
+
+//! Every BTH key in the format is four bytes or fewer
+inline ulong bth_read_at(const std::vector<byte>& alloc, size_t offset, size_t width)
+{
+    ulong value = 0;
+    memcpy(&value, &alloc[offset], width);
+    return value;
+}
+
+inline void bth_write_at(std::vector<byte>& alloc, size_t offset, size_t width, ulong value)
+{
+    memcpy(&alloc[offset], &value, width);
+}
+
+//! Walk a BTH to the allocation holding an exact key, recording the path
+template<typename T>
+inline void bth_descend(heap_writer<T>& heap, const bth_layout& layout, ulong key,
+                        std::vector<heap_id>& path, std::vector<uint>& indices)
+{
+    heap_id current = layout.root;
+
+    for(byte level = layout.levels; level > 0; --level)
+    {
+        std::vector<byte> alloc = heap.read_alloc(current);
+        const uint count = (uint)(alloc.size() / layout.nonleaf_stride());
+
+        if(count == 0 || key < bth_read_at(alloc, 0, layout.key_size))
+            throw key_not_found<ulong>(key);
+
+        uint position = 0;
+        while(position + 1 < count &&
+              bth_read_at(alloc, (position + 1) * layout.nonleaf_stride(), layout.key_size) <= key)
+            ++position;
+
+        path.push_back(current);
+        indices.push_back(position);
+        current = (heap_id)bth_read_at(alloc, position * layout.nonleaf_stride() + layout.key_size,
+                                       sizeof(heap_id));
+    }
+
+    std::vector<byte> alloc = heap.read_alloc(current);
+    const uint count = (uint)(alloc.size() / layout.leaf_stride());
+
+    for(uint i = 0; i < count; ++i)
+    {
+        if(bth_read_at(alloc, i * layout.leaf_stride(), layout.key_size) != key)
+            continue;
+
+        path.push_back(current);
+        indices.push_back(i);
+        return;
+    }
+
+    throw key_not_found<ulong>(key);
+}
+
+//! Drop one leaf entry, fixing the ancestors that named the leaf by its first key
+template<typename T>
+inline void bth_remove_key(heap_writer<T>& heap, const bth_layout& layout, ulong key)
+{
+    std::vector<heap_id> path;
+    std::vector<uint> indices;
+    bth_descend(heap, layout, key, path, indices);
+
+    const size_t stride = layout.leaf_stride();
+    std::vector<byte> alloc = heap.read_alloc(path.back());
+    const uint count = (uint)(alloc.size() / stride);
+    const uint index = indices.back();
+
+    if(index + 1 < count)
+        memmove(&alloc[index * stride], &alloc[(index + 1) * stride],
+                (count - index - 1) * stride);
+
+    heap.write_alloc(path.back(), alloc);
+    heap.shrink_alloc(path.back(), (count - 1) * stride);
+
+    if(count > 1)
+    {
+        if(index != 0 || path.size() < 2)
+            return;
+
+        std::vector<byte> survivors = heap.read_alloc(path.back());
+        const ulong first = bth_read_at(survivors, 0, layout.key_size);
+
+        for(size_t depth = path.size() - 1; depth-- > 0;)
+        {
+            std::vector<byte> parent = heap.read_alloc(path[depth]);
+            bth_write_at(parent, indices[depth] * layout.nonleaf_stride(), layout.key_size, first);
+            heap.write_alloc(path[depth], parent);
+
+            if(indices[depth] != 0)
+                return;
+        }
+
+        return;
+    }
+
+    // the leaf is empty, so take it out of its parent, and keep going if that
+    // empties the parent too
+    const size_t nonleaf = layout.nonleaf_stride();
+    for(size_t depth = path.size() - 1; depth-- > 0;)
+    {
+        std::vector<byte> parent = heap.read_alloc(path[depth]);
+        const uint parent_count = (uint)(parent.size() / nonleaf);
+        const uint parent_index = indices[depth];
+
+        if(parent_index + 1 < parent_count)
+            memmove(&parent[parent_index * nonleaf], &parent[(parent_index + 1) * nonleaf],
+                    (parent_count - parent_index - 1) * nonleaf);
+
+        heap.write_alloc(path[depth], parent);
+        heap.shrink_alloc(path[depth], (parent_count - 1) * nonleaf);
+
+        if(parent_count > 1)
+            return;
+    }
+}
+
+} // end detail namespace
+} // end pstsdk namespace
+
+template<typename T>
+inline void pstsdk::pc_set_inline(db_writer<T>& writer, node_id nid, prop_id id, ulong value)
+{
+    heap_writer<T> heap(writer, nid);
+    detail::bth_layout layout = detail::bth_read_layout(heap, heap.root_id());
+
+    std::vector<heap_id> path;
+    std::vector<uint> indices;
+
+    // the BTH works in erased four byte keys, so restore the caller's key type
+    try { detail::bth_descend(heap, layout, id, path, indices); }
+    catch(key_not_found<ulong>&) { throw key_not_found<prop_id>(id); }
+
+    std::vector<byte> alloc = heap.read_alloc(path.back());
+    const size_t value_at = layout.value_offset(indices.back());
+
+    // a prop_entry is a two byte type followed by the value, and anything four
+    // bytes or under lives in that field rather than behind it
+    const ulong type = detail::bth_read_at(alloc, value_at, sizeof(ushort));
+    if(type != prop_type_long && type != prop_type_boolean)
+        throw not_implemented("pc_set_inline only handles inline fixed width properties");
+
+    detail::bth_write_at(alloc, value_at + sizeof(ushort), sizeof(ulong), value);
+    heap.write_alloc(path.back(), alloc);
+}
+
+template<typename T>
+inline void pstsdk::tc_remove_row(db_writer<T>& writer, node_id nid, row_id id)
+{
+    heap_writer<T> heap(writer, nid);
+    const heap_id root = heap.root_id();
+
+    std::vector<byte> raw = heap.read_alloc(root);
+    const disk::tc_header* header = reinterpret_cast<const disk::tc_header*>(&raw[0]);
+
+    if(header->signature != disk::heap_sig_tc)
+        throw database_corrupt("not a table context");
+
+    const size_t cb_per_row = header->size_offsets[disk::tc_offsets_bitmap];
+    const heap_id row_btree = header->row_btree_id;
+    const heapnode_id matrix = header->row_matrix_id;
+
+    if(matrix == 0)
+        throw key_not_found<row_id>(id);
+
+    // Every table in every store under test/ keeps its matrix inline. A folder
+    // big enough to outgrow a heap allocation moves it into a subnode, which
+    // needs a block level shrink instead and is not handled yet.
+    if(is_subnode_id(matrix))
+        throw not_implemented("row matrix held in a subnode");
+
+    detail::bth_layout layout = detail::bth_read_layout(heap, row_btree);
+
+    std::vector<byte> rows = heap.read_alloc(matrix);
+    const size_t count = cb_per_row ? rows.size() / cb_per_row : 0;
+
+    if(count == 0)
+        throw key_not_found<row_id>(id);
+
+    std::vector<heap_id> path;
+    std::vector<uint> indices;
+    detail::bth_descend(heap, layout, id, path, indices);
+
+    std::vector<byte> leaf = heap.read_alloc(path.back());
+    const size_t target = detail::bth_read_at(leaf, layout.value_offset(indices.back()),
+                                              layout.value_size);
+    const size_t last = count - 1;
+
+    if(target != last)
+    {
+        // the moved row keeps its id, so the index has to learn its new position
+        row_id moved;
+        memcpy(&moved, &rows[last * cb_per_row], sizeof(row_id));
+        memcpy(&rows[target * cb_per_row], &rows[last * cb_per_row], cb_per_row);
+        heap.write_alloc(matrix, rows);
+
+        std::vector<heap_id> moved_path;
+        std::vector<uint> moved_indices;
+        detail::bth_descend(heap, layout, moved, moved_path, moved_indices);
+
+        std::vector<byte> moved_leaf = heap.read_alloc(moved_path.back());
+        detail::bth_write_at(moved_leaf, layout.value_offset(moved_indices.back()),
+                             layout.value_size, (ulong)target);
+        heap.write_alloc(moved_path.back(), moved_leaf);
+    }
+
+    heap.shrink_alloc(matrix, last * cb_per_row);
+    detail::bth_remove_key(heap, layout, id);
+
+    if(last > 0)
+        return;
+
+    // an emptied table carries neither a matrix nor a row index root on disk,
+    // which is what one that was never populated looks like
+    std::vector<byte> bth_raw = heap.read_alloc(row_btree);
+    reinterpret_cast<disk::bth_header*>(&bth_raw[0])->root = 0;
+    heap.write_alloc(row_btree, bth_raw);
+
+    std::vector<byte> header_raw = heap.read_alloc(root);
+    reinterpret_cast<disk::tc_header*>(&header_raw[0])->row_matrix_id = 0;
+    heap.write_alloc(root, header_raw);
+}
+//! \endcond
+
+#endif

--- a/pstsdk/ndb.h
+++ b/pstsdk/ndb.h
@@ -6,5 +6,6 @@
 #include "pstsdk/ndb/database_iface.h"
 #include "pstsdk/ndb/node.h"
 #include "pstsdk/ndb/page.h"
+#include "pstsdk/ndb/writer.h"
 
 #endif

--- a/pstsdk/ndb/database.h
+++ b/pstsdk/ndb/database.h
@@ -27,7 +27,7 @@ namespace pstsdk
 
 class node;
 
-template<typename T>
+template<typename T> 
 class database_impl;
 typedef database_impl<ulonglong> large_pst;
 typedef database_impl<ulong> small_pst;

--- a/pstsdk/ndb/database.h
+++ b/pstsdk/ndb/database.h
@@ -27,10 +27,15 @@ namespace pstsdk
 
 class node;
 
-template<typename T> 
+template<typename T>
 class database_impl;
 typedef database_impl<ulonglong> large_pst;
 typedef database_impl<ulong> small_pst;
+
+//! \cond write_api
+template<typename T>
+class db_writer;
+//! \endcond
 
 //! \brief Open a db_context for the given file
 //! \throws invalid_format if the file format is not understood
@@ -213,6 +218,20 @@ protected:
     friend std::shared_ptr<small_pst> open_small_pst(std::shared_ptr<file> file);
     friend std::shared_ptr<large_pst> open_large_pst(const std::wstring& filename);
     friend std::shared_ptr<large_pst> open_large_pst(std::shared_ptr<file> file);
+
+//! \cond write_api
+    template<typename> friend class db_writer;
+
+    file& get_file() { return *m_file; }
+    disk::header<T>& get_header() { return m_header; }
+
+    //! \brief Drop the cached NBT and BBT roots
+    //!
+    //! Nothing else in the library invalidates them, and every
+    //! bt_nonleaf_page::m_child_pages hanging off them caches the pre-mutation
+    //! tree, so dropping the roots is what drops the whole cached subtree.
+    void reset_page_cache() { m_bbt_root.reset(); m_nbt_root.reset(); }
+//! \endcond
 
     std::shared_ptr<file> m_file;
     disk::header<T> m_header;

--- a/pstsdk/ndb/writer.h
+++ b/pstsdk/ndb/writer.h
@@ -154,6 +154,20 @@ public:
     //! \param[in] nid The node to walk
     std::vector<block_id> node_external_blocks(node_id nid);
 
+    //! \brief Zero every byte the store does not reference
+    //!
+    //! Deleting an item scrubs what that item owned, but a store arrives already
+    //! carrying text in space its original client freed years earlier, and that
+    //! is just as readable. This clears all of it.
+    //!
+    //! What survives is the header region, the allocation map pages at their
+    //! fixed offsets, every BTree page, and every block the BBT still lists.
+    //! BTree pages are the trap: they are allocated from bidNextP and never
+    //! appear in the BBT, so anything that treats "outside the BBT" as free
+    //! destroys the store.
+    //! \returns The number of bytes zeroed
+    ulonglong wipe_free_space();
+
     //! \brief Mark the header as needing a restamp on the next \ref commit
     void touch() { m_dirty = true; }
 
@@ -205,6 +219,11 @@ private:
     void apply_release(const std::map<block_id, ushort>& remaining,
                        const std::map<block_id, block_info>& info,
                        const std::vector<block_id>& order);
+
+    //! Every page of a BTree, leaf and nonleaf alike
+    void collect_pages(ulonglong address, std::vector<ulonglong>& pages);
+    //! Whether a 512 byte window validates as a page of any kind
+    bool looks_like_page(ulonglong address);
 
     ulonglong nbt_root() const { return m_db->get_header().root_info.brefNBT.ib; }
     ulonglong bbt_root() const { return m_db->get_header().root_info.brefBBT.ib; }
@@ -906,6 +925,127 @@ inline void pstsdk::db_writer<T>::delete_node(node_id nid)
 
     nbt_remove(nid);
     apply_release(remaining, info, order);
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::collect_pages(ulonglong address, std::vector<ulonglong>& pages)
+{
+    pages.push_back(address);
+
+    std::vector<byte> page = read_page_raw(address);
+    if(bt_level(page) == 0)
+        return;
+
+    for(uint i = 0; i < bt_count(page); ++i)
+        collect_pages(bt_child(page, i), pages);
+}
+
+// Rather than working out where every kind of allocation map page is supposed to
+// sit, ask the bytes. A page carries its type twice and a CRC over its contents,
+// so anything that validates is a real page of some kind and is left alone. That
+// covers the AMaps, the DList and the deprecated PMap and FMap pages without
+// this code having to know their spacing.
+template<typename T>
+inline bool pstsdk::db_writer<T>::looks_like_page(ulonglong address)
+{
+    std::vector<byte> page(disk::page_size);
+
+    try { m_db->get_file().read(page, address); }
+    catch(std::out_of_range&) { return false; }
+
+    const disk::page<T>* p = reinterpret_cast<const disk::page<T>*>(&page[0]);
+
+    if(p->trailer.page_type != p->trailer.page_type_repeat)
+        return false;
+
+    switch(p->trailer.page_type)
+    {
+    case disk::page_type_bbt:
+    case disk::page_type_nbt:
+    case disk::page_type_fmap:
+    case disk::page_type_pmap:
+    case disk::page_type_amap:
+    case disk::page_type_fpmap:
+    case disk::page_type_dlist:
+        break;
+    default:
+        return false;
+    }
+
+    return p->trailer.crc == disk::compute_crc(&page[0], disk::page<T>::page_data_size);
+}
+
+template<typename T>
+inline pstsdk::ulonglong pstsdk::db_writer<T>::wipe_free_space()
+{
+    const ulonglong eof = m_db->get_header().root_info.ibFileEof;
+    const ulonglong first = disk::first_amap_page_location;
+
+    std::vector<std::pair<ulonglong, ulonglong> > live;
+
+    // the header, the DList and everything reserved ahead of the first AMap
+    live.push_back(std::make_pair((ulonglong)0, first));
+
+    std::vector<ulonglong> pages;
+    collect_pages(nbt_root(), pages);
+    collect_pages(bbt_root(), pages);
+    for(size_t i = 0; i < pages.size(); ++i)
+        live.push_back(std::make_pair(pages[i], pages[i] + disk::page_size));
+
+    std::shared_ptr<bbt_page> root = m_db->read_bbt_root();
+    for(const_blockinfo_iterator i = root->begin(); i != root->end(); ++i)
+        live.push_back(std::make_pair((*i).address,
+                                      (*i).address + disk::align_disk<T>((*i).size)));
+
+    std::sort(live.begin(), live.end());
+
+    // Anything left in the gaps that still validates as a page is an allocation
+    // map page of some kind. Asking the bytes beats working out where each kind
+    // is meant to sit, and it covers the deprecated PMap and FMap pages too.
+    std::vector<std::pair<ulonglong, ulonglong> > keep;
+    ulonglong at = 0;
+
+    for(size_t i = 0; i <= live.size(); ++i)
+    {
+        const ulonglong stop = i < live.size() ? live[i].first : eof;
+
+        ulonglong page = at < first ? first : at;
+        if((page - first) % disk::page_size)
+            page += disk::page_size - ((page - first) % disk::page_size);
+
+        for(; page + disk::page_size <= stop; page += disk::page_size)
+            if(looks_like_page(page))
+                keep.push_back(std::make_pair(page, page + disk::page_size));
+
+        if(i < live.size() && live[i].second > at)
+            at = live[i].second;
+    }
+
+    live.insert(live.end(), keep.begin(), keep.end());
+    std::sort(live.begin(), live.end());
+
+    ulonglong wiped = 0;
+    at = 0;
+
+    for(size_t i = 0; i < live.size(); ++i)
+    {
+        if(live[i].first > at)
+        {
+            zero_extent(at, (size_t)(live[i].first - at));
+            wiped += live[i].first - at;
+        }
+
+        if(live[i].second > at)
+            at = live[i].second;
+    }
+
+    if(eof > at)
+    {
+        zero_extent(at, (size_t)(eof - at));
+        wiped += eof - at;
+    }
+
+    return wiped;
 }
 
 template<typename T>

--- a/pstsdk/ndb/writer.h
+++ b/pstsdk/ndb/writer.h
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <map>
 #include <vector>
 
 #include "pstsdk/util/errors.h"
@@ -147,6 +148,17 @@ private:
     void collect_data_tree(block_id bid, std::vector<block_id>& blocks);
     //! Walk a subnode tree, appending its blocks and those of every subnode
     void collect_subnode_tree(block_id bid, std::vector<block_id>& blocks);
+
+    //! The blocks an internal block points at, or nothing for an external one
+    void block_children(block_id bid, std::vector<block_id>& children);
+
+    //! Work out what dropping a reference to a tree costs, without changing anything
+    void plan_release(block_id root, std::map<block_id, ushort>& remaining,
+                      std::map<block_id, block_info>& info, std::vector<block_id>& order);
+    //! Carry out a plan: rewrite the counts that dropped, unlink and scrub the rest
+    void apply_release(const std::map<block_id, ushort>& remaining,
+                       const std::map<block_id, block_info>& info,
+                       const std::vector<block_id>& order);
 
     ulonglong nbt_root() const { return m_db->get_header().root_info.brefNBT.ib; }
     ulonglong bbt_root() const { return m_db->get_header().root_info.brefBBT.ib; }
@@ -530,40 +542,143 @@ inline std::vector<pstsdk::block_id> pstsdk::db_writer<T>::node_external_blocks(
 }
 
 template<typename T>
-inline void pstsdk::db_writer<T>::release_block(block_id bid)
+inline void pstsdk::db_writer<T>::block_children(block_id bid, std::vector<block_id>& children)
 {
-    block_info bi = m_db->lookup_block_info(bid);
+    if(disk::bid_is_external(bid))
+        return;
 
-    if(bi.ref_count > disk::block_unreferenced + 1)
+    std::vector<byte> raw = read_block(bid);
+
+    if(raw[0] == disk::block_type_extended)
     {
-        bbt_set_ref_count(bid, (ushort)(bi.ref_count - 1));
+        const disk::extended_block<T>* xblock =
+            reinterpret_cast<const disk::extended_block<T>*>(&raw[0]);
+
+        for(ushort i = 0; i < xblock->count; ++i)
+            children.push_back(xblock->bid[i]);
+
         return;
     }
 
-    const ulonglong address = bi.address;
-    const size_t extent = disk::align_disk<T>(bi.size);
+    if(raw[0] != disk::block_type_sub)
+        throw unexpected_block("unknown internal block type");
 
-    bbt_remove(bid);
-    zero_extent(address, extent);
+    const disk::sub_block<T, disk::sub_leaf_entry<T> >* leaf =
+        reinterpret_cast<const disk::sub_block<T, disk::sub_leaf_entry<T> >*>(&raw[0]);
+
+    if(leaf->level == 0)
+    {
+        for(ushort i = 0; i < leaf->count; ++i)
+        {
+            children.push_back(leaf->entry[i].data);
+            children.push_back(leaf->entry[i].sub);
+        }
+
+        return;
+    }
+
+    const disk::sub_block<T, disk::sub_nonleaf_entry<T> >* nonleaf =
+        reinterpret_cast<const disk::sub_block<T, disk::sub_nonleaf_entry<T> >*>(&raw[0]);
+
+    for(ushort i = 0; i < nonleaf->count; ++i)
+        children.push_back(nonleaf->entry[i].sub_block_bid);
+}
+
+// A block that keeps a reference keeps its children with it, so the walk stops at
+// anything that survives. Descending past one and freeing what it points at would
+// pull the data out from under whoever still owns it. Real stores do share
+// extended and subnode blocks, so this is not hypothetical.
+template<typename T>
+inline void pstsdk::db_writer<T>::plan_release(block_id root,
+                                               std::map<block_id, ushort>& remaining,
+                                               std::map<block_id, block_info>& info,
+                                               std::vector<block_id>& order)
+{
+    std::vector<block_id> pending;
+    pending.push_back(root);
+
+    while(!pending.empty())
+    {
+        const block_id raw = pending.back();
+        pending.pop_back();
+
+        if(raw == 0)
+            continue;
+
+        const block_id bid = raw & ~(block_id(disk::block_id_attached_bit));
+
+        if(remaining.find(bid) == remaining.end())
+        {
+            const block_info bi = m_db->lookup_block_info(bid);
+            info[bid] = bi;
+            remaining[bid] = bi.ref_count;
+            order.push_back(bid);
+        }
+
+        if(remaining[bid] <= disk::block_unreferenced)
+            throw database_corrupt("block released more often than it is referenced");
+
+        --remaining[bid];
+
+        if(remaining[bid] > disk::block_unreferenced)
+            continue;
+
+        block_children(bid, pending);
+    }
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::apply_release(const std::map<block_id, ushort>& remaining,
+                                                const std::map<block_id, block_info>& info,
+                                                const std::vector<block_id>& order)
+{
+    for(size_t i = 0; i < order.size(); ++i)
+    {
+        const block_id bid = order[i];
+        const ushort count = remaining.find(bid)->second;
+
+        if(count > disk::block_unreferenced)
+        {
+            bbt_set_ref_count(bid, count);
+            continue;
+        }
+
+        const block_info& bi = info.find(bid)->second;
+        const ulonglong address = bi.address;
+        const size_t extent = disk::align_disk<T>(bi.size);
+
+        bbt_remove(bid);
+        zero_extent(address, extent);
+    }
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::release_block(block_id bid)
+{
+    std::map<block_id, ushort> remaining;
+    std::map<block_id, block_info> info;
+    std::vector<block_id> order;
+
+    plan_release(bid, remaining, info, order);
+    apply_release(remaining, info, order);
 }
 
 template<typename T>
 inline void pstsdk::db_writer<T>::delete_node(node_id nid)
 {
-    node_info ni = m_db->lookup_node_info(nid);
+    const node_info ni = m_db->lookup_node_info(nid);
 
-    std::vector<block_id> blocks;
-    collect_data_tree(ni.data_bid, blocks);
-    collect_subnode_tree(ni.sub_bid, blocks);
+    // Both trees are read before the first write, because neither is reachable
+    // once the NBT entry is gone.
+    std::map<block_id, ushort> remaining;
+    std::map<block_id, block_info> info;
+    std::vector<block_id> order;
 
-    // a block reachable twice within one node must still only lose one reference
-    std::sort(blocks.begin(), blocks.end());
-    blocks.erase(std::unique(blocks.begin(), blocks.end()), blocks.end());
+    plan_release(ni.data_bid, remaining, info, order);
+    plan_release(ni.sub_bid, remaining, info, order);
 
     nbt_remove(nid);
-
-    for(size_t i = 0; i < blocks.size(); ++i)
-        release_block(blocks[i]);
+    apply_release(remaining, info, order);
 }
 
 template<typename T>

--- a/pstsdk/ndb/writer.h
+++ b/pstsdk/ndb/writer.h
@@ -101,6 +101,28 @@ public:
     //! \param[in] nid The node to delete
     void delete_node(node_id nid);
 
+    //! \brief The data block of one of a node's subnodes
+    //! \throws key_not_found<node_id> if the node has no such subnode
+    //! \param[in] nid The node owning the subnode tree
+    //! \param[in] sub The subnode to find
+    block_id subnode_data(node_id nid, node_id sub);
+
+    //! \brief The external blocks of a data tree, in logical order
+    //! \param[in] bid The root of the tree
+    std::vector<block_id> external_blocks(block_id bid);
+
+    //! \brief Shrink the last external block of a data tree
+    //!
+    //! Passing zero drops the block instead, taking it out of its parent and
+    //! releasing it, which is how a row matrix gives back a whole page. The
+    //! parent's total_size is kept in step because
+    //! \ref extended_block::get_page_count derives the page count from it and
+    //! asserts the result against the real child count.
+    //! \param[in] bid The root of the tree
+    //! \param[in] new_size The last block's new size, or zero to drop it
+    //! \returns true when the tree has no blocks left
+    bool shrink_data_tail(block_id bid, size_t new_size);
+
     //! \brief The external blocks making up a node's data, in logical order
     //!
     //! A heap spans these blocks, one heap block apiece, so this is how the LTP
@@ -526,12 +548,10 @@ inline void pstsdk::db_writer<T>::collect_subnode_tree(block_id bid, std::vector
 }
 
 template<typename T>
-inline std::vector<pstsdk::block_id> pstsdk::db_writer<T>::node_external_blocks(node_id nid)
+inline std::vector<pstsdk::block_id> pstsdk::db_writer<T>::external_blocks(block_id bid)
 {
-    node_info ni = m_db->lookup_node_info(nid);
-
     std::vector<block_id> tree;
-    collect_data_tree(ni.data_bid, tree);
+    collect_data_tree(bid, tree);
 
     std::vector<block_id> external;
     for(size_t i = 0; i < tree.size(); ++i)
@@ -539,6 +559,96 @@ inline std::vector<pstsdk::block_id> pstsdk::db_writer<T>::node_external_blocks(
             external.push_back(tree[i]);
 
     return external;
+}
+
+template<typename T>
+inline std::vector<pstsdk::block_id> pstsdk::db_writer<T>::node_external_blocks(node_id nid)
+{
+    return external_blocks(m_db->lookup_node_info(nid).data_bid);
+}
+
+template<typename T>
+inline pstsdk::block_id pstsdk::db_writer<T>::subnode_data(node_id nid, node_id sub)
+{
+    std::vector<block_id> pending;
+    pending.push_back(m_db->lookup_node_info(nid).sub_bid);
+
+    while(!pending.empty())
+    {
+        const block_id bid = pending.back();
+        pending.pop_back();
+
+        if(bid == 0)
+            continue;
+
+        std::vector<byte> raw = read_block(bid);
+        const disk::sub_block<T, disk::sub_leaf_entry<T> >* leaf =
+            reinterpret_cast<const disk::sub_block<T, disk::sub_leaf_entry<T> >*>(&raw[0]);
+
+        if(leaf->level != 0)
+        {
+            const disk::sub_block<T, disk::sub_nonleaf_entry<T> >* nonleaf =
+                reinterpret_cast<const disk::sub_block<T, disk::sub_nonleaf_entry<T> >*>(&raw[0]);
+
+            for(ushort i = 0; i < nonleaf->count; ++i)
+                pending.push_back(nonleaf->entry[i].sub_block_bid);
+
+            continue;
+        }
+
+        for(ushort i = 0; i < leaf->count; ++i)
+            if(leaf->entry[i].nid == sub)
+                return leaf->entry[i].data;
+    }
+
+    throw key_not_found<node_id>(sub);
+}
+
+template<typename T>
+inline bool pstsdk::db_writer<T>::shrink_data_tail(block_id bid, size_t new_size)
+{
+    if(disk::bid_is_external(bid))
+    {
+        if(new_size == 0)
+            return true;
+
+        std::vector<byte> payload = read_block(bid);
+        payload.resize(new_size);
+        write_block(bid, payload);
+        return false;
+    }
+
+    std::vector<byte> raw = read_block(bid);
+    disk::extended_block<T>* xblock = reinterpret_cast<disk::extended_block<T>*>(&raw[0]);
+
+    if(xblock->block_type != disk::block_type_extended)
+        throw unexpected_block("expected an extended block in a data tree");
+
+    if(xblock->count == 0)
+        return true;
+
+    const ushort last = (ushort)(xblock->count - 1);
+    const block_id child = xblock->bid[last];
+    const size_t was = m_db->lookup_block_info(child).size;
+
+    if(!shrink_data_tail(child, new_size))
+    {
+        xblock->total_size -= (ulong)(was - new_size);
+        write_block(bid, raw);
+        return false;
+    }
+
+    // the child gave up its last row, so it leaves the tree with it
+    xblock->total_size -= (ulong)was;
+    xblock->bid[last] = 0;
+    --xblock->count;
+
+    if(xblock->count == 0)
+        return true;
+
+    write_block(bid, raw);
+    release_block(child);
+    return false;
 }
 
 template<typename T>

--- a/pstsdk/ndb/writer.h
+++ b/pstsdk/ndb/writer.h
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <cstring>
 #include <map>
+#include <set>
 #include <vector>
 
 #include "pstsdk/util/errors.h"
@@ -344,10 +345,21 @@ inline void pstsdk::db_writer<T>::bt_descend(ulonglong root, T key,
                                              std::vector<uint>& indices)
 {
     ulonglong address = root;
+    uint above = 0;
+    bool descending = false;
 
     for(;;)
     {
         std::vector<byte> page = read_page_raw(address);
+
+        // Levels strictly decrease on the way down. A tree that says otherwise is
+        // corrupt, and following it would never terminate.
+        if(descending && bt_level(page) >= above)
+            throw database_corrupt("btree level did not decrease");
+
+        above = bt_level(page);
+        descending = true;
+
         int position = bt_search(page, key);
 
         if(position < 0)
@@ -579,6 +591,7 @@ inline typename pstsdk::db_writer<T>::data_ref
 pstsdk::db_writer<T>::subnode_ref(block_id tree, node_id sub)
 {
     std::vector<block_id> pending;
+    std::set<block_id> seen;
     pending.push_back(tree);
 
     while(!pending.empty())
@@ -587,6 +600,10 @@ pstsdk::db_writer<T>::subnode_ref(block_id tree, node_id sub)
         pending.pop_back();
 
         if(bid == 0)
+            continue;
+
+        // a subnode tree that names a block twice would otherwise be walked forever
+        if(!seen.insert(bid & ~(block_id(disk::block_id_attached_bit))).second)
             continue;
 
         std::vector<byte> raw = read_block(bid);

--- a/pstsdk/ndb/writer.h
+++ b/pstsdk/ndb/writer.h
@@ -16,6 +16,7 @@
 #ifndef PSTSDK_NDB_WRITER_H
 #define PSTSDK_NDB_WRITER_H
 
+#include <algorithm>
 #include <cstring>
 #include <vector>
 
@@ -82,6 +83,23 @@ public:
     //! \param[in] count The new count, where \ref disk::block_unreferenced means free
     void bbt_set_ref_count(block_id bid, ushort count);
 
+    //! \brief Drop one reference to a block, scrubbing it when the last one goes
+    //!
+    //! A block still owned by someone else keeps its bytes and only loses a
+    //! reference. The last owner's departure zeroes the block's whole aligned
+    //! extent, which is what actually removes the data from the store.
+    //! \param[in] bid The block to release
+    void release_block(block_id bid);
+
+    //! \brief Unlink a node and scrub everything only it owned
+    //!
+    //! Collects the node's data tree and subnode tree first, because neither is
+    //! reachable once the NBT entry is gone, then unlinks before scrubbing so the
+    //! store is structurally valid at every point in between.
+    //! \throws key_not_found<node_id> if the node is not in the tree
+    //! \param[in] nid The node to delete
+    void delete_node(node_id nid);
+
     //! \brief Mark the header as needing a restamp on the next \ref commit
     void touch() { m_dirty = true; }
 
@@ -117,6 +135,11 @@ private:
                           size_t depth, T key);
     //! Locate a leaf entry so a caller can patch its non-key fields in place
     void bt_find(ulonglong root, T key, ulonglong& address, uint& index);
+
+    //! Walk a data tree, appending every block that makes it up
+    void collect_data_tree(block_id bid, std::vector<block_id>& blocks);
+    //! Walk a subnode tree, appending its blocks and those of every subnode
+    void collect_subnode_tree(block_id bid, std::vector<block_id>& blocks);
 
     ulonglong nbt_root() const { return m_db->get_header().root_info.brefNBT.ib; }
     ulonglong bbt_root() const { return m_db->get_header().root_info.brefBBT.ib; }
@@ -424,6 +447,100 @@ inline void pstsdk::db_writer<T>::bbt_set_ref_count(block_id bid, ushort count)
         reinterpret_cast<disk::bbt_leaf_entry<T>*>(&page[index * bt_entry_size(page)]);
     entry->ref_count = count;
     write_page_raw(address, page);
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::collect_data_tree(block_id bid, std::vector<block_id>& blocks)
+{
+    if(bid == 0)
+        return;
+
+    blocks.push_back(bid);
+
+    if(disk::bid_is_external(bid))
+        return;
+
+    std::vector<byte> raw = read_block(bid);
+    const disk::extended_block<T>* xblock =
+        reinterpret_cast<const disk::extended_block<T>*>(&raw[0]);
+
+    if(xblock->block_type != disk::block_type_extended)
+        throw unexpected_block("expected an extended block in a data tree");
+
+    for(ushort i = 0; i < xblock->count; ++i)
+        collect_data_tree(xblock->bid[i], blocks);
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::collect_subnode_tree(block_id bid, std::vector<block_id>& blocks)
+{
+    if(bid == 0)
+        return;
+
+    blocks.push_back(bid);
+
+    std::vector<byte> raw = read_block(bid);
+    const disk::sub_block<T, disk::sub_leaf_entry<T> >* sblock =
+        reinterpret_cast<const disk::sub_block<T, disk::sub_leaf_entry<T> >*>(&raw[0]);
+
+    if(sblock->block_type != disk::block_type_sub)
+        throw unexpected_block("expected a subnode block in a subnode tree");
+
+    if(sblock->level == 0)
+    {
+        for(ushort i = 0; i < sblock->count; ++i)
+        {
+            // a subnode owns a data tree and a subnode tree of its own, which is
+            // how attachments and embedded messages hang off a message
+            collect_data_tree(sblock->entry[i].data, blocks);
+            collect_subnode_tree(sblock->entry[i].sub, blocks);
+        }
+
+        return;
+    }
+
+    const disk::sub_block<T, disk::sub_nonleaf_entry<T> >* nonleaf =
+        reinterpret_cast<const disk::sub_block<T, disk::sub_nonleaf_entry<T> >*>(&raw[0]);
+
+    for(ushort i = 0; i < nonleaf->count; ++i)
+        collect_subnode_tree(nonleaf->entry[i].sub_block_bid, blocks);
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::release_block(block_id bid)
+{
+    block_info bi = m_db->lookup_block_info(bid);
+
+    if(bi.ref_count > disk::block_unreferenced + 1)
+    {
+        bbt_set_ref_count(bid, (ushort)(bi.ref_count - 1));
+        return;
+    }
+
+    const ulonglong address = bi.address;
+    const size_t extent = disk::align_disk<T>(bi.size);
+
+    bbt_remove(bid);
+    zero_extent(address, extent);
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::delete_node(node_id nid)
+{
+    node_info ni = m_db->lookup_node_info(nid);
+
+    std::vector<block_id> blocks;
+    collect_data_tree(ni.data_bid, blocks);
+    collect_subnode_tree(ni.sub_bid, blocks);
+
+    // a block reachable twice within one node must still only lose one reference
+    std::sort(blocks.begin(), blocks.end());
+    blocks.erase(std::unique(blocks.begin(), blocks.end()), blocks.end());
+
+    nbt_remove(nid);
+
+    for(size_t i = 0; i < blocks.size(); ++i)
+        release_block(blocks[i]);
 }
 
 template<typename T>

--- a/pstsdk/ndb/writer.h
+++ b/pstsdk/ndb/writer.h
@@ -180,6 +180,8 @@ private:
                        const std::vector<block_id>& order);
 
     void collect_pages(ulonglong address, std::vector<ulonglong>& pages);
+    //! The bytes a block stands for, which for an extended block is not its size
+    size_t logical_size(block_id bid);
     bool looks_like_page(ulonglong address);
 
     ulonglong nbt_root() const { return m_db->get_header().root_info.brefNBT.ib; }
@@ -632,15 +634,19 @@ inline bool pstsdk::db_writer<T>::subnode_remove(block_id tree, node_id sub)
         disk::sub_block<T, disk::sub_nonleaf_entry<T> >* nonleaf =
             reinterpret_cast<disk::sub_block<T, disk::sub_nonleaf_entry<T> >*>(&raw[0]);
 
-        for(ushort i = 0; i < nonleaf->count; ++i)
+        // entries are ordered by nid, so the subtree that can hold sub is the
+        // last one whose key does not exceed it
+        ushort i = 0;
+        while(i + 1 < nonleaf->count && nonleaf->entry[i + 1].nid_key <= sub)
+            ++i;
+
+        if(nonleaf->count == 0 || sub < nonleaf->entry[0].nid_key)
+            throw key_not_found<node_id>(sub);
+
         {
             block_id child = nonleaf->entry[i].sub_block_bid;
 
-            bool emptied = false;
-            try { emptied = subnode_remove(child, sub); }
-            catch(key_not_found<node_id>&) { continue; }
-
-            if(!emptied)
+            if(!subnode_remove(child, sub))
                 return false;
 
             if(i + 1 < nonleaf->count)
@@ -656,8 +662,6 @@ inline bool pstsdk::db_writer<T>::subnode_remove(block_id tree, node_id sub)
             release_block(child);
             return false;
         }
-
-        throw key_not_found<node_id>(sub);
     }
 
     for(ushort i = 0; i < leaf->count; ++i)
@@ -674,10 +678,9 @@ inline bool pstsdk::db_writer<T>::subnode_remove(block_id tree, node_id sub)
         memset(&leaf->entry[leaf->count - 1], 0, sizeof(disk::sub_leaf_entry<T>));
         --leaf->count;
 
-        // the entry is gone from the block before anything it pointed at is
-        // released, so the store never references a scrubbed block
-        if(leaf->count > 0)
-            write_block(tree, raw);
+        // the entry has to reach disk before anything it named is released, or
+        // the store is left pointing at scrubbed blocks
+        write_block(tree, raw);
 
         std::map<block_id, ushort> remaining;
         std::map<block_id, block_info> info;
@@ -717,7 +720,7 @@ inline bool pstsdk::db_writer<T>::shrink_data_tail(block_id bid, size_t new_size
 
     const ushort last = (ushort)(xblock->count - 1);
     const block_id child = xblock->bid[last];
-    const size_t was = m_db->lookup_block_info(child).size;
+    const size_t was = logical_size(child);
 
     if(!shrink_data_tail(child, new_size))
     {
@@ -726,17 +729,31 @@ inline bool pstsdk::db_writer<T>::shrink_data_tail(block_id bid, size_t new_size
         return false;
     }
 
-    // the child gave up its last row, so it leaves the tree with it
+    // The child emptied. If it was the only one the whole tree goes, and the
+    // caller releases the root rather than this dismantling it halfway.
+    if(xblock->count == 1)
+        return true;
+
     xblock->total_size -= (ulong)was;
     xblock->bid[last] = 0;
     --xblock->count;
 
-    if(xblock->count == 0)
-        return true;
-
     write_block(bid, raw);
     release_block(child);
     return false;
+}
+
+// A block's BBT size is its own length. For an extended block that is the bid
+// array, not the bytes it stands for, which is what the parent's total_size
+// counts.
+template<typename T>
+inline size_t pstsdk::db_writer<T>::logical_size(block_id bid)
+{
+    if(disk::bid_is_external(bid))
+        return m_db->lookup_block_info(bid).size;
+
+    std::vector<byte> raw = read_block(bid);
+    return reinterpret_cast<const disk::extended_block<T>*>(&raw[0])->total_size;
 }
 
 template<typename T>
@@ -1001,8 +1018,18 @@ inline void pstsdk::db_writer<T>::zero_extent(ulonglong address, size_t size)
     if(size == 0)
         return;
 
-    std::vector<byte> zeroes(size, 0);
-    m_db->get_file().write(zeroes, address);
+    const size_t chunk = 1024 * 1024;
+    std::vector<byte> zeroes(size < chunk ? size : chunk, 0);
+
+    for(ulonglong at = address; at < address + size; at += zeroes.size())
+    {
+        const ulonglong left = address + size - at;
+        if(left < zeroes.size())
+            zeroes.resize((size_t)left);
+
+        m_db->get_file().write(zeroes, at);
+    }
+
     m_dirty = true;
 }
 

--- a/pstsdk/ndb/writer.h
+++ b/pstsdk/ndb/writer.h
@@ -1,0 +1,481 @@
+//! \file
+//! \brief In place edits of an open store
+//!
+//! Every edit here writes back to the address it read from, at the same size or
+//! smaller. That is what lets the library delete items without owning an
+//! allocator: nothing is ever relocated, no block or page is ever created, and
+//! the space that falls out is recovered by the client's AMap rebuild rather
+//! than by us.
+//!
+//! The two rules that fall out of having no allocator:
+//! - a block with more than one reference can be unlinked but never modified,
+//!   because there is nowhere to copy it to first
+//! - a block can shrink but never grow
+//! \ingroup ndb
+
+#ifndef PSTSDK_NDB_WRITER_H
+#define PSTSDK_NDB_WRITER_H
+
+#include <cstring>
+#include <vector>
+
+#include "pstsdk/util/errors.h"
+#include "pstsdk/util/primitives.h"
+
+#include "pstsdk/ndb/database.h"
+
+namespace pstsdk
+{
+
+//! \cond write_api
+
+//! \brief Performs in place edits on an open store
+//!
+//! Holds no state of its own beyond a dirty flag; the store's header lives in
+//! the \ref database_impl and is flushed by \ref commit.
+//! \tparam T ulonglong for a Unicode store, ulong for an ANSI store
+//! \ingroup ndb_databaserelated
+template<typename T>
+class db_writer
+{
+public:
+    explicit db_writer(const std::shared_ptr<database_impl<T> >& db)
+        : m_db(db), m_dirty(false) { }
+
+    //! \brief Read a block's payload, decoded
+    //! \param[in] bid The block to read
+    //! \returns Exactly the block's unaligned size in bytes
+    std::vector<byte> read_block(block_id bid);
+
+    //! \brief Write a payload back over the block it came from
+    //!
+    //! Encodes, stamps a fresh trailer at the position the new size implies, and
+    //! zeroes the old extent first when the block shrinks past a slot boundary.
+    //! \throws can_not_resize if the payload is larger than the block
+    //! \throws shared_block if the block has more than one reference
+    //! \param[in] bid The block to overwrite
+    //! \param[in] payload The new contents, at most the block's current size
+    void write_block(block_id bid, const std::vector<byte>& payload);
+
+    //! \brief Overwrite a range of the file with zeroes
+    //! \param[in] address The offset to start at
+    //! \param[in] size The number of bytes to zero
+    void zero_extent(ulonglong address, size_t size);
+
+    //! \brief Remove a node's entry from the NBT
+    //! \throws key_not_found<node_id> if the node is not in the tree
+    //! \param[in] nid The node to unlink
+    void nbt_remove(node_id nid);
+
+    //! \brief Remove a block's entry from the BBT
+    //! \throws key_not_found<block_id> if the block is not in the tree
+    //! \param[in] bid The block to unlink
+    void bbt_remove(block_id bid);
+
+    //! \brief Overwrite the unaligned size recorded for a block
+    //! \param[in] bid The block to update
+    //! \param[in] cb The block's new unaligned size
+    void bbt_set_size(block_id bid, ushort cb);
+
+    //! \brief Overwrite the reference count recorded for a block
+    //! \param[in] bid The block to update
+    //! \param[in] count The new count, where \ref disk::block_unreferenced means free
+    void bbt_set_ref_count(block_id bid, ushort count);
+
+    //! \brief Mark the header as needing a restamp on the next \ref commit
+    void touch() { m_dirty = true; }
+
+    //! \brief Flush the header and drop the store's cached BTree roots
+    //!
+    //! Invalidates the AMaps so the client rebuilds them, which is what actually
+    //! returns the freed slots. Does nothing if no edit has been made.
+    void commit();
+
+private:
+    //! Offset of a BTree page's four metadata bytes: count, max, entry size, level
+    static const size_t bt_meta = disk::page<T>::page_data_size - sizeof(T);
+
+    static uint bt_count(const std::vector<byte>& page) { return page[bt_meta]; }
+    static uint bt_entry_size(const std::vector<byte>& page) { return page[bt_meta + 2]; }
+    static uint bt_level(const std::vector<byte>& page) { return page[bt_meta + 3]; }
+
+    //! The key is the first field of every entry type, leaf and nonleaf alike
+    static T bt_key(const std::vector<byte>& page, uint index);
+    static void bt_set_key(std::vector<byte>& page, uint index, T key);
+    //! A nonleaf entry is a key then a block_reference, so the address trails both
+    static ulonglong bt_child(const std::vector<byte>& page, uint index);
+    static int bt_search(const std::vector<byte>& page, T key);
+
+    std::vector<byte> read_page_raw(ulonglong address);
+    void write_page_raw(ulonglong address, std::vector<byte>& page);
+
+    //! Walk to the leaf holding an exact key, recording the path taken
+    void bt_descend(ulonglong root, T key, std::vector<ulonglong>& path, std::vector<uint>& indices);
+    void bt_remove(ulonglong root, T key);
+    //! Retarget the ancestors that named a page by its old first key
+    void bt_propagate_key(const std::vector<ulonglong>& path, const std::vector<uint>& indices,
+                          size_t depth, T key);
+    //! Locate a leaf entry so a caller can patch its non-key fields in place
+    void bt_find(ulonglong root, T key, ulonglong& address, uint& index);
+
+    ulonglong nbt_root() const { return m_db->get_header().root_info.brefNBT.ib; }
+    ulonglong bbt_root() const { return m_db->get_header().root_info.brefBBT.ib; }
+
+    void stamp_header_crc();
+
+    std::shared_ptr<database_impl<T> > m_db;
+    bool m_dirty;
+};
+
+//! \endcond
+
+} // end pstsdk namespace
+
+//! \cond write_api
+template<typename T>
+inline std::vector<pstsdk::byte> pstsdk::db_writer<T>::read_block(block_id bid)
+{
+    block_info bi = m_db->lookup_block_info(bid);
+    std::vector<byte> buffer = m_db->read_block_data(bi);
+    buffer.resize(bi.size);
+
+    if(bi.size == 0 || !disk::bid_is_external(bi.id))
+        return buffer;
+
+    if(m_db->get_header().bCryptMethod == disk::crypt_method_permute)
+        disk::permute(&buffer[0], bi.size, false);
+    else if(m_db->get_header().bCryptMethod == disk::crypt_method_cyclic)
+        disk::cyclic(&buffer[0], bi.size, (ulong)bi.id);
+
+    return buffer;
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::write_block(block_id bid, const std::vector<byte>& payload)
+{
+    block_info bi = m_db->lookup_block_info(bid);
+
+    if(payload.size() > bi.size)
+        throw can_not_resize("write_block cannot grow a block");
+
+    if(bi.ref_count > disk::block_unreferenced + 1)
+        throw shared_block("cannot edit a block in place while it is shared");
+
+    const size_t new_cb = payload.size();
+    const size_t old_aligned = disk::align_disk<T>(bi.size);
+    const size_t new_aligned = disk::align_disk<T>(new_cb);
+
+    std::vector<byte> buffer(new_aligned, 0);
+    if(new_cb > 0)
+    {
+        memcpy(&buffer[0], &payload[0], new_cb);
+
+        // extended and subnode blocks are stored plain; only external blocks
+        // carry the store's encoding
+        if(disk::bid_is_external(bi.id))
+        {
+            if(m_db->get_header().bCryptMethod == disk::crypt_method_permute)
+                disk::permute(&buffer[0], (ulong)new_cb, true);
+            else if(m_db->get_header().bCryptMethod == disk::crypt_method_cyclic)
+                disk::cyclic(&buffer[0], (ulong)new_cb, (ulong)bi.id);
+        }
+    }
+
+    disk::block_trailer<T>* bt = reinterpret_cast<disk::block_trailer<T>*>(
+        &buffer[0] + new_aligned - sizeof(disk::block_trailer<T>));
+    bt->cb = (ushort)new_cb;
+    bt->signature = disk::compute_signature(bi.id, bi.address);
+    bt->bid = bi.id;
+    // over the encoded bytes: read_block_data checks the CRC before
+    // read_external_block gets a chance to decode
+    bt->crc = disk::compute_crc(&buffer[0], (ulong)new_cb);
+
+    // a shrink past a slot boundary moves the trailer, so the old one has to go
+    if(new_aligned < old_aligned)
+        zero_extent(bi.address, old_aligned);
+
+    m_db->get_file().write(buffer, bi.address);
+    m_dirty = true;
+
+    if(new_cb != bi.size)
+        bbt_set_size(bid, (ushort)new_cb);
+}
+
+template<typename T>
+inline T pstsdk::db_writer<T>::bt_key(const std::vector<byte>& page, uint index)
+{
+    T key;
+    memcpy(&key, &page[index * bt_entry_size(page)], sizeof(T));
+    return key;
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::bt_set_key(std::vector<byte>& page, uint index, T key)
+{
+    memcpy(&page[index * bt_entry_size(page)], &key, sizeof(T));
+}
+
+template<typename T>
+inline pstsdk::ulonglong pstsdk::db_writer<T>::bt_child(const std::vector<byte>& page, uint index)
+{
+    T address;
+    memcpy(&address, &page[index * bt_entry_size(page) + 2 * sizeof(T)], sizeof(T));
+    return address;
+}
+
+// Mirrors btree_node::binary_search: the last entry whose key is <= the target, or
+// -1 when the target sorts below everything on the page.
+template<typename T>
+inline int pstsdk::db_writer<T>::bt_search(const std::vector<byte>& page, T key)
+{
+    uint start = 0;
+    uint end = bt_count(page);
+    uint mid = (start + end) / 2;
+
+    while(mid < end)
+    {
+        T current = bt_key(page, mid);
+
+        if(current < key)
+            start = mid + 1;
+        else if(current == key)
+            return (int)mid;
+        else
+            end = mid;
+
+        mid = (start + end) / 2;
+    }
+
+    return (int)mid - 1;
+}
+
+template<typename T>
+inline std::vector<pstsdk::byte> pstsdk::db_writer<T>::read_page_raw(ulonglong address)
+{
+    std::vector<byte> page(disk::page_size);
+    m_db->get_file().read(page, address);
+    return page;
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::write_page_raw(ulonglong address, std::vector<byte>& page)
+{
+    disk::page<T>* p = reinterpret_cast<disk::page<T>*>(&page[0]);
+    p->trailer.signature = disk::compute_signature((T)p->trailer.bid, (T)address);
+    p->trailer.crc = disk::compute_crc(&page[0], disk::page<T>::page_data_size);
+
+    m_db->get_file().write(page, address);
+
+    // the store caches its BTree roots forever and never invalidates them, so any
+    // page edit has to drop the cache or subsequent lookups read the old tree
+    m_db->reset_page_cache();
+    m_dirty = true;
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::bt_descend(ulonglong root, T key,
+                                             std::vector<ulonglong>& path,
+                                             std::vector<uint>& indices)
+{
+    ulonglong address = root;
+
+    for(;;)
+    {
+        std::vector<byte> page = read_page_raw(address);
+        int position = bt_search(page, key);
+
+        if(position < 0)
+            throw key_not_found<T>(key);
+
+        path.push_back(address);
+        indices.push_back((uint)position);
+
+        if(bt_level(page) == 0)
+        {
+            if(bt_key(page, (uint)position) != key)
+                throw key_not_found<T>(key);
+            return;
+        }
+
+        address = bt_child(page, (uint)position);
+    }
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::bt_propagate_key(const std::vector<ulonglong>& path,
+                                                   const std::vector<uint>& indices,
+                                                   size_t depth, T key)
+{
+    while(depth > 0)
+    {
+        size_t parent = depth - 1;
+        std::vector<byte> page = read_page_raw(path[parent]);
+        bt_set_key(page, indices[parent], key);
+        write_page_raw(path[parent], page);
+
+        // only a change to the parent's own first entry keeps rippling upward
+        if(indices[parent] != 0)
+            return;
+
+        depth = parent;
+    }
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::bt_remove(ulonglong root, T key)
+{
+    std::vector<ulonglong> path;
+    std::vector<uint> indices;
+    bt_descend(root, key, path, indices);
+
+    // Bail before touching anything if this would cascade all the way up: the
+    // removal below zeroes pages as it climbs, so discovering it at the root would
+    // leave the tree half dismantled.
+    bool empties_root = true;
+    for(size_t depth = 0; depth < path.size() && empties_root; ++depth)
+    {
+        std::vector<byte> page = read_page_raw(path[depth]);
+        empties_root = bt_count(page) == 1;
+    }
+    if(empties_root)
+        throw database_corrupt("btree root emptied");
+
+    for(size_t depth = path.size(); depth-- > 0;)
+    {
+        std::vector<byte> page = read_page_raw(path[depth]);
+        const uint count = bt_count(page);
+        const uint entry_size = bt_entry_size(page);
+        const uint index = indices[depth];
+
+        if(index + 1 < count)
+            memmove(&page[index * entry_size], &page[(index + 1) * entry_size],
+                    (count - index - 1) * entry_size);
+        memset(&page[(count - 1) * entry_size], 0, entry_size);
+        page[bt_meta] = (byte)(count - 1);
+
+        if(count > 1)
+        {
+            write_page_raw(path[depth], page);
+
+            // [MS-PST] 2.2.2.7.7.2 defines a nonleaf key as its child's first key,
+            // so dropping entry zero leaves every ancestor naming a key that moved
+            if(index == 0)
+                bt_propagate_key(path, indices, depth, bt_key(page, 0));
+
+            return;
+        }
+
+        // An empty page is not merely untidy: btree_node_nonleaf::first indexes
+        // child zero unguarded and last underflows num_values() - 1, so end() is
+        // poisoned as soon as one exists. Drop it from its parent instead.
+        if(depth == 0)
+            throw database_corrupt("btree root emptied");
+
+        zero_extent(path[depth], disk::page_size);
+    }
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::bt_find(ulonglong root, T key, ulonglong& address, uint& index)
+{
+    std::vector<ulonglong> path;
+    std::vector<uint> indices;
+    bt_descend(root, key, path, indices);
+
+    address = path.back();
+    index = indices.back();
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::nbt_remove(node_id nid)
+{
+    bt_remove(nbt_root(), (T)nid);
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::bbt_remove(block_id bid)
+{
+    bt_remove(bbt_root(), (T)(bid & ~(block_id(disk::block_id_attached_bit))));
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::bbt_set_size(block_id bid, ushort cb)
+{
+    ulonglong address;
+    uint index;
+    bt_find(bbt_root(), (T)(bid & ~(block_id(disk::block_id_attached_bit))), address, index);
+
+    std::vector<byte> page = read_page_raw(address);
+    disk::bbt_leaf_entry<T>* entry =
+        reinterpret_cast<disk::bbt_leaf_entry<T>*>(&page[index * bt_entry_size(page)]);
+    entry->size = cb;
+    write_page_raw(address, page);
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::bbt_set_ref_count(block_id bid, ushort count)
+{
+    ulonglong address;
+    uint index;
+    bt_find(bbt_root(), (T)(bid & ~(block_id(disk::block_id_attached_bit))), address, index);
+
+    std::vector<byte> page = read_page_raw(address);
+    disk::bbt_leaf_entry<T>* entry =
+        reinterpret_cast<disk::bbt_leaf_entry<T>*>(&page[index * bt_entry_size(page)]);
+    entry->ref_count = count;
+    write_page_raw(address, page);
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::zero_extent(ulonglong address, size_t size)
+{
+    if(size == 0)
+        return;
+
+    std::vector<byte> zeroes(size, 0);
+    m_db->get_file().write(zeroes, address);
+    m_dirty = true;
+}
+
+template<typename T>
+inline void pstsdk::db_writer<T>::commit()
+{
+    if(!m_dirty)
+        return;
+
+    disk::header<T>& h = m_db->get_header();
+    h.root_info.fAMapValid = disk::invalid_amap;
+    ++h.dwUnique;
+    stamp_header_crc();
+
+    std::vector<byte> buffer(sizeof(disk::header<T>));
+    memcpy(&buffer[0], &h, sizeof(disk::header<T>));
+    m_db->get_file().write(buffer, 0);
+
+    m_db->reset_page_cache();
+    m_dirty = false;
+}
+
+template<>
+inline void pstsdk::db_writer<pstsdk::ulong>::stamp_header_crc()
+{
+    disk::header<ulong>& h = m_db->get_header();
+    h.dwCRCPartial = disk::compute_crc(
+        reinterpret_cast<byte*>(&h) + disk::header_crc_locations<ulong>::start,
+        disk::header_crc_locations<ulong>::length);
+}
+
+template<>
+inline void pstsdk::db_writer<pstsdk::ulonglong>::stamp_header_crc()
+{
+    disk::header<ulonglong>& h = m_db->get_header();
+    h.dwCRCPartial = disk::compute_crc(
+        reinterpret_cast<byte*>(&h) + disk::header_crc_locations<ulonglong>::partial_start,
+        disk::header_crc_locations<ulonglong>::partial_length);
+    h.dwCRCFull = disk::compute_crc(
+        reinterpret_cast<byte*>(&h) + disk::header_crc_locations<ulonglong>::full_start,
+        disk::header_crc_locations<ulonglong>::full_length);
+}
+//! \endcond
+
+#endif

--- a/pstsdk/ndb/writer.h
+++ b/pstsdk/ndb/writer.h
@@ -100,6 +100,13 @@ public:
     //! \param[in] nid The node to delete
     void delete_node(node_id nid);
 
+    //! \brief The external blocks making up a node's data, in logical order
+    //!
+    //! A heap spans these blocks, one heap block apiece, so this is how the LTP
+    //! layer turns a heap page number into something it can write.
+    //! \param[in] nid The node to walk
+    std::vector<block_id> node_external_blocks(node_id nid);
+
     //! \brief Mark the header as needing a restamp on the next \ref commit
     void touch() { m_dirty = true; }
 
@@ -504,6 +511,22 @@ inline void pstsdk::db_writer<T>::collect_subnode_tree(block_id bid, std::vector
 
     for(ushort i = 0; i < nonleaf->count; ++i)
         collect_subnode_tree(nonleaf->entry[i].sub_block_bid, blocks);
+}
+
+template<typename T>
+inline std::vector<pstsdk::block_id> pstsdk::db_writer<T>::node_external_blocks(node_id nid)
+{
+    node_info ni = m_db->lookup_node_info(nid);
+
+    std::vector<block_id> tree;
+    collect_data_tree(ni.data_bid, tree);
+
+    std::vector<block_id> external;
+    for(size_t i = 0; i < tree.size(); ++i)
+        if(disk::bid_is_external(tree[i]))
+            external.push_back(tree[i]);
+
+    return external;
 }
 
 template<typename T>

--- a/pstsdk/ndb/writer.h
+++ b/pstsdk/ndb/writer.h
@@ -2,15 +2,12 @@
 //! \brief In place edits of an open store
 //!
 //! Every edit here writes back to the address it read from, at the same size or
-//! smaller. That is what lets the library delete items without owning an
-//! allocator: nothing is ever relocated, no block or page is ever created, and
-//! the space that falls out is recovered by the client's AMap rebuild rather
-//! than by us.
+//! smaller. Nothing is relocated, no block or page is ever created, and the
+//! space that falls out is recovered by the client's AMap rebuild rather than
+//! by us.
 //!
-//! The two rules that fall out of having no allocator:
-//! - a block with more than one reference can be unlinked but never modified,
-//!   because there is nowhere to copy it to first
-//! - a block can shrink but never grow
+//! A block with more than one reference can be unlinked but never modified,
+//! because there is nowhere to copy it to first.
 //! \ingroup ndb
 
 #ifndef PSTSDK_NDB_WRITER_H
@@ -59,44 +56,16 @@ public:
     //! \param[in] payload The new contents, at most the block's current size
     void write_block(block_id bid, const std::vector<byte>& payload);
 
-    //! \brief Overwrite a range of the file with zeroes
-    //! \param[in] address The offset to start at
-    //! \param[in] size The number of bytes to zero
-    void zero_extent(ulonglong address, size_t size);
-
     //! \brief Remove a node's entry from the NBT
     //! \throws key_not_found<node_id> if the node is not in the tree
     //! \param[in] nid The node to unlink
     void nbt_remove(node_id nid);
 
-    //! \brief Remove a block's entry from the BBT
-    //! \throws key_not_found<block_id> if the block is not in the tree
-    //! \param[in] bid The block to unlink
-    void bbt_remove(block_id bid);
-
-    //! \brief Overwrite the unaligned size recorded for a block
-    //! \param[in] bid The block to update
-    //! \param[in] cb The block's new unaligned size
-    void bbt_set_size(block_id bid, ushort cb);
-
-    //! \brief Overwrite the reference count recorded for a block
-    //! \param[in] bid The block to update
-    //! \param[in] count The new count, where \ref disk::block_unreferenced means free
-    void bbt_set_ref_count(block_id bid, ushort count);
-
-    //! \brief Drop one reference to a block, scrubbing it when the last one goes
-    //!
-    //! A block still owned by someone else keeps its bytes and only loses a
-    //! reference. The last owner's departure zeroes the block's whole aligned
-    //! extent, which is what actually removes the data from the store.
-    //! \param[in] bid The block to release
-    void release_block(block_id bid);
-
     //! \brief Unlink a node and scrub everything only it owned
     //!
-    //! Collects the node's data tree and subnode tree first, because neither is
-    //! reachable once the NBT entry is gone, then unlinks before scrubbing so the
-    //! store is structurally valid at every point in between.
+    //! Both trees are collected first, because neither is reachable once the NBT
+    //! entry is gone, then unlinked before scrubbing so the store stays
+    //! structurally valid throughout.
     //! \throws key_not_found<node_id> if the node is not in the tree
     //! \param[in] nid The node to delete
     void delete_node(node_id nid);
@@ -147,29 +116,16 @@ public:
     //! \returns true when the tree has no blocks left
     bool shrink_data_tail(block_id bid, size_t new_size);
 
-    //! \brief The external blocks making up a node's data, in logical order
-    //!
-    //! A heap spans these blocks, one heap block apiece, so this is how the LTP
-    //! layer turns a heap page number into something it can write.
-    //! \param[in] nid The node to walk
-    std::vector<block_id> node_external_blocks(node_id nid);
 
     //! \brief Zero every byte the store does not reference
     //!
-    //! Deleting an item scrubs what that item owned, but a store arrives already
-    //! carrying text in space its original client freed years earlier, and that
-    //! is just as readable. This clears all of it.
-    //!
-    //! What survives is the header region, the allocation map pages at their
-    //! fixed offsets, every BTree page, and every block the BBT still lists.
-    //! BTree pages are the trap: they are allocated from bidNextP and never
-    //! appear in the BBT, so anything that treats "outside the BBT" as free
-    //! destroys the store.
+    //! What survives is the header region, every page that validates as one, and
+    //! every block the BBT lists. BTree pages are the trap: they come from
+    //! bidNextP and never appear in the BBT, so anything treating "outside the
+    //! BBT" as free destroys the store.
     //! \returns The number of bytes zeroed
     ulonglong wipe_free_space();
 
-    //! \brief Mark the header as needing a restamp on the next \ref commit
-    void touch() { m_dirty = true; }
 
     //! \brief Flush the header and drop the store's cached BTree roots
     //!
@@ -178,6 +134,13 @@ public:
     void commit();
 
 private:
+    void zero_extent(ulonglong address, size_t size);
+    void bbt_remove(block_id bid);
+    void bbt_set_size(block_id bid, ushort cb);
+    void bbt_set_ref_count(block_id bid, ushort count);
+    //! A block someone else still owns keeps its bytes and only loses a reference
+    void release_block(block_id bid);
+
     //! Offset of a BTree page's four metadata bytes: count, max, entry size, level
     static const size_t bt_meta = disk::page<T>::page_data_size - sizeof(T);
 
@@ -195,7 +158,6 @@ private:
     std::vector<byte> read_page_raw(ulonglong address);
     void write_page_raw(ulonglong address, std::vector<byte>& page);
 
-    //! Walk to the leaf holding an exact key, recording the path taken
     void bt_descend(ulonglong root, T key, std::vector<ulonglong>& path, std::vector<uint>& indices);
     void bt_remove(ulonglong root, T key);
     //! Retarget the ancestors that named a page by its old first key
@@ -204,12 +166,9 @@ private:
     //! Locate a leaf entry so a caller can patch its non-key fields in place
     void bt_find(ulonglong root, T key, ulonglong& address, uint& index);
 
-    //! Walk a data tree, appending every block that makes it up
     void collect_data_tree(block_id bid, std::vector<block_id>& blocks);
-    //! Walk a subnode tree, appending its blocks and those of every subnode
     void collect_subnode_tree(block_id bid, std::vector<block_id>& blocks);
 
-    //! The blocks an internal block points at, or nothing for an external one
     void block_children(block_id bid, std::vector<block_id>& children);
 
     //! Work out what dropping a reference to a tree costs, without changing anything
@@ -220,9 +179,7 @@ private:
                        const std::map<block_id, block_info>& info,
                        const std::vector<block_id>& order);
 
-    //! Every page of a BTree, leaf and nonleaf alike
     void collect_pages(ulonglong address, std::vector<ulonglong>& pages);
-    //! Whether a 512 byte window validates as a page of any kind
     bool looks_like_page(ulonglong address);
 
     ulonglong nbt_root() const { return m_db->get_header().root_info.brefNBT.ib; }
@@ -604,11 +561,6 @@ inline std::vector<pstsdk::block_id> pstsdk::db_writer<T>::external_blocks(block
     return external;
 }
 
-template<typename T>
-inline std::vector<pstsdk::block_id> pstsdk::db_writer<T>::node_external_blocks(node_id nid)
-{
-    return external_blocks(m_db->lookup_node_info(nid).data_bid);
-}
 
 template<typename T>
 inline typename pstsdk::db_writer<T>::data_ref pstsdk::db_writer<T>::node_ref(node_id nid)
@@ -914,8 +866,6 @@ inline void pstsdk::db_writer<T>::delete_node(node_id nid)
 {
     const node_info ni = m_db->lookup_node_info(nid);
 
-    // Both trees are read before the first write, because neither is reachable
-    // once the NBT entry is gone.
     std::map<block_id, ushort> remaining;
     std::map<block_id, block_info> info;
     std::vector<block_id> order;
@@ -999,9 +949,6 @@ inline pstsdk::ulonglong pstsdk::db_writer<T>::wipe_free_space()
 
     std::sort(live.begin(), live.end());
 
-    // Anything left in the gaps that still validates as a page is an allocation
-    // map page of some kind. Asking the bytes beats working out where each kind
-    // is meant to sit, and it covers the deprecated PMap and FMap pages too.
     std::vector<std::pair<ulonglong, ulonglong> > keep;
     ulonglong at = 0;
 

--- a/pstsdk/ndb/writer.h
+++ b/pstsdk/ndb/writer.h
@@ -101,11 +101,35 @@ public:
     //! \param[in] nid The node to delete
     void delete_node(node_id nid);
 
-    //! \brief The data block of one of a node's subnodes
-    //! \throws key_not_found<node_id> if the node has no such subnode
-    //! \param[in] nid The node owning the subnode tree
+    //! \brief Where a node or subnode keeps its data and its own subnodes
+    //!
+    //! Subnodes carry both, which is how a message's attachment table has a heap
+    //! of its own and a row matrix hanging off it.
+    struct data_ref
+    {
+        block_id data;
+        block_id sub;
+    };
+
+    //! \brief The pair belonging to a top level node
+    //! \throws key_not_found<node_id> if the node is not in the store
+    data_ref node_ref(node_id nid);
+
+    //! \brief The pair belonging to a subnode of a given subnode tree
+    //! \throws key_not_found<node_id> if the tree has no such subnode
+    //! \param[in] tree The root of the subnode tree to search
     //! \param[in] sub The subnode to find
-    block_id subnode_data(node_id nid, node_id sub);
+    data_ref subnode_ref(block_id tree, node_id sub);
+
+    //! \brief Drop a subnode from a subnode tree and release what it owned
+    //!
+    //! The entry count governs, so the block keeps its size and only loses the
+    //! entry. Empty leaves are taken out of their parent the same way.
+    //! \throws key_not_found<node_id> if the tree has no such subnode
+    //! \param[in] tree The root of the subnode tree
+    //! \param[in] sub The subnode to remove
+    //! \returns true when the tree has no subnodes left
+    bool subnode_remove(block_id tree, node_id sub);
 
     //! \brief The external blocks of a data tree, in logical order
     //! \param[in] bid The root of the tree
@@ -568,10 +592,21 @@ inline std::vector<pstsdk::block_id> pstsdk::db_writer<T>::node_external_blocks(
 }
 
 template<typename T>
-inline pstsdk::block_id pstsdk::db_writer<T>::subnode_data(node_id nid, node_id sub)
+inline typename pstsdk::db_writer<T>::data_ref pstsdk::db_writer<T>::node_ref(node_id nid)
+{
+    const node_info ni = m_db->lookup_node_info(nid);
+    data_ref ref;
+    ref.data = ni.data_bid;
+    ref.sub = ni.sub_bid;
+    return ref;
+}
+
+template<typename T>
+inline typename pstsdk::db_writer<T>::data_ref
+pstsdk::db_writer<T>::subnode_ref(block_id tree, node_id sub)
 {
     std::vector<block_id> pending;
-    pending.push_back(m_db->lookup_node_info(nid).sub_bid);
+    pending.push_back(tree);
 
     while(!pending.empty())
     {
@@ -597,8 +632,90 @@ inline pstsdk::block_id pstsdk::db_writer<T>::subnode_data(node_id nid, node_id 
         }
 
         for(ushort i = 0; i < leaf->count; ++i)
-            if(leaf->entry[i].nid == sub)
-                return leaf->entry[i].data;
+        {
+            if(leaf->entry[i].nid != sub)
+                continue;
+
+            data_ref ref;
+            ref.data = leaf->entry[i].data;
+            ref.sub = leaf->entry[i].sub;
+            return ref;
+        }
+    }
+
+    throw key_not_found<node_id>(sub);
+}
+
+template<typename T>
+inline bool pstsdk::db_writer<T>::subnode_remove(block_id tree, node_id sub)
+{
+    if(tree == 0)
+        throw key_not_found<node_id>(sub);
+
+    std::vector<byte> raw = read_block(tree);
+    disk::sub_block<T, disk::sub_leaf_entry<T> >* leaf =
+        reinterpret_cast<disk::sub_block<T, disk::sub_leaf_entry<T> >*>(&raw[0]);
+
+    if(leaf->level != 0)
+    {
+        disk::sub_block<T, disk::sub_nonleaf_entry<T> >* nonleaf =
+            reinterpret_cast<disk::sub_block<T, disk::sub_nonleaf_entry<T> >*>(&raw[0]);
+
+        for(ushort i = 0; i < nonleaf->count; ++i)
+        {
+            block_id child = nonleaf->entry[i].sub_block_bid;
+
+            bool emptied = false;
+            try { emptied = subnode_remove(child, sub); }
+            catch(key_not_found<node_id>&) { continue; }
+
+            if(!emptied)
+                return false;
+
+            if(i + 1 < nonleaf->count)
+                memmove(&nonleaf->entry[i], &nonleaf->entry[i + 1],
+                        (nonleaf->count - i - 1) * sizeof(disk::sub_nonleaf_entry<T>));
+            memset(&nonleaf->entry[nonleaf->count - 1], 0, sizeof(disk::sub_nonleaf_entry<T>));
+            --nonleaf->count;
+
+            if(nonleaf->count == 0)
+                return true;
+
+            write_block(tree, raw);
+            release_block(child);
+            return false;
+        }
+
+        throw key_not_found<node_id>(sub);
+    }
+
+    for(ushort i = 0; i < leaf->count; ++i)
+    {
+        if(leaf->entry[i].nid != sub)
+            continue;
+
+        const block_id data = leaf->entry[i].data;
+        const block_id owned = leaf->entry[i].sub;
+
+        if(i + 1 < leaf->count)
+            memmove(&leaf->entry[i], &leaf->entry[i + 1],
+                    (leaf->count - i - 1) * sizeof(disk::sub_leaf_entry<T>));
+        memset(&leaf->entry[leaf->count - 1], 0, sizeof(disk::sub_leaf_entry<T>));
+        --leaf->count;
+
+        // the entry is gone from the block before anything it pointed at is
+        // released, so the store never references a scrubbed block
+        if(leaf->count > 0)
+            write_block(tree, raw);
+
+        std::map<block_id, ushort> remaining;
+        std::map<block_id, block_info> info;
+        std::vector<block_id> order;
+        plan_release(data, remaining, info, order);
+        plan_release(owned, remaining, info, order);
+        apply_release(remaining, info, order);
+
+        return leaf->count == 0;
     }
 
     throw key_not_found<node_id>(sub);

--- a/pstsdk/pst.h
+++ b/pstsdk/pst.h
@@ -68,6 +68,7 @@
 
 #include "pstsdk/pst/pst.h"
 #include "pstsdk/pst/folder.h"
+#include "pstsdk/pst/delete.h"
 #include "pstsdk/pst/message.h"
 
 #endif

--- a/pstsdk/pst/delete.h
+++ b/pstsdk/pst/delete.h
@@ -130,6 +130,40 @@ inline std::vector<row_id> table_row_ids(const shared_db_ptr& db, node_id owner,
     return rows;
 }
 
+//! Every search folder's contents table, which caches copies of the columns it
+//! indexes and so has to lose a deleted message's row along with the real folder.
+//! The GUST is skipped: open_table refuses to parse it at all.
+inline std::vector<node_id> search_contents_tables(const shared_db_ptr& db)
+{
+    std::vector<node_id> tables;
+    std::shared_ptr<nbt_page> root = db->read_nbt_root();
+
+    for(const_nodeinfo_iterator i = root->begin(); i != root->end(); ++i)
+    {
+        if(get_nid_type((*i).id) != nid_type_search_contents_table)
+            continue;
+
+        if((*i).id == nid_all_message_search_contents)
+            continue;
+
+        tables.push_back((*i).id);
+    }
+
+    return tables;
+}
+
+template<typename T>
+inline void sweep_search_folders(db_writer<T>& writer, const std::vector<node_id>& tables,
+                                 node_id message)
+{
+    for(size_t i = 0; i < tables.size(); ++i)
+    {
+        try { tc_remove_row(writer, tables[i], message); }
+        catch(key_not_found<row_id>&) { }
+        catch(database_corrupt&) { }
+    }
+}
+
 inline node_id folder_table(node_id folder, nid_type type)
 {
     return make_nid(type, get_nid_index(folder));
@@ -177,6 +211,8 @@ inline void delete_message_impl(const std::shared_ptr<database_impl<T> >& db, no
     const bool has_unread = try_read_long(db, folder, PR_CONTENT_UNREAD, unread_count);
     const bool has_associated = try_read_long(db, folder, PR_ASSOC_CONTENT_COUNT, associated_count);
 
+    const std::vector<node_id> search = search_contents_tables(db);
+
     db_writer<T> writer(db);
 
     bool associated = false;
@@ -190,6 +226,8 @@ inline void delete_message_impl(const std::shared_ptr<database_impl<T> >& db, no
 
     if(removed && !associated && unread && has_unread && unread_count > 0)
         pc_set_inline(writer, folder, (prop_id)PR_CONTENT_UNREAD, unread_count - 1);
+
+    sweep_search_folders(writer, search, nid);
 
     writer.delete_node(nid);
     writer.commit();
@@ -228,13 +266,13 @@ inline void delete_attachment_impl(const std::shared_ptr<database_impl<T> >& db,
 
 template<typename T>
 inline void delete_folder_contents(db_writer<T>& writer, const std::shared_ptr<database_impl<T> >& db,
-                                   node_id folder)
+                                   node_id folder, const std::vector<node_id>& search)
 {
     const std::vector<row_id> subfolders =
         table_row_ids(db, folder_table(folder, nid_type_hierarchy_table));
 
     for(size_t i = 0; i < subfolders.size(); ++i)
-        delete_folder_contents(writer, db, subfolders[i]);
+        delete_folder_contents(writer, db, subfolders[i], search);
 
     // The tables go with the folder, so the messages only need their nodes
     // unlinked; there is no row left to take them out of.
@@ -244,7 +282,10 @@ inline void delete_folder_contents(db_writer<T>& writer, const std::shared_ptr<d
         table_row_ids(db, folder_table(folder, nid_type_associated_contents_table));
 
     for(size_t i = 0; i < messages.size(); ++i)
+    {
+        sweep_search_folders(writer, search, (node_id)messages[i]);
         writer.delete_node(messages[i]);
+    }
 
     for(size_t i = 0; i < associated.size(); ++i)
         writer.delete_node(associated[i]);
@@ -269,6 +310,7 @@ inline void delete_folder_impl(const std::shared_ptr<database_impl<T> >& db, nod
 
     const size_t siblings =
         table_row_ids(db, folder_table(parent, nid_type_hierarchy_table)).size();
+    const std::vector<node_id> search = search_contents_tables(db);
 
     db_writer<T> writer(db);
 
@@ -285,7 +327,7 @@ inline void delete_folder_impl(const std::shared_ptr<database_impl<T> >& db, nod
         }
     }
 
-    delete_folder_contents(writer, db, nid);
+    delete_folder_contents(writer, db, nid, search);
     writer.commit();
 }
 

--- a/pstsdk/pst/delete.h
+++ b/pstsdk/pst/delete.h
@@ -32,10 +32,10 @@ namespace pstsdk
 
 //! \cond write_api
 
-//! \brief The \ref PR_MESSAGE_FLAGS bit that marks a message read
+//! \brief The \ref PR_MESSAGE_FLAGS bit marking a message read
 //!
-//! Needed because an unread message costs its folder a count in
-//! \ref PR_CONTENT_UNREAD as well as one in \ref PR_CONTENT_COUNT.
+//! An unread message costs its folder a \ref PR_CONTENT_UNREAD as well as a
+//! \ref PR_CONTENT_COUNT.
 //! \sa [MS-OXCMSG] 2.2.1.6
 const slong mapi_message_read = 0x1;
 
@@ -94,7 +94,7 @@ namespace pstsdk
 namespace detail
 {
 
-//! Read a property that may not be there, without disturbing the store
+//! An absent property leaves value untouched and reads as false
 inline bool try_read_long(const shared_db_ptr& db, node_id nid, prop_id id, slong& value)
 {
     try
@@ -128,7 +128,6 @@ inline std::vector<row_id> table_row_ids(const shared_db_ptr& db, node_id nid)
     return rows;
 }
 
-//! The row ids of a table carried by one of a node's subnodes
 inline std::vector<row_id> table_row_ids(const shared_db_ptr& db, node_id owner, node_id sub)
 {
     std::vector<row_id> rows;
@@ -170,7 +169,6 @@ inline void sweep_search_folders(db_writer<T>& writer, const std::vector<node_id
     {
         try { tc_remove_row(writer, tables[i], message); }
         catch(key_not_found<row_id>&) { }
-        catch(database_corrupt&) { }
     }
 }
 
@@ -275,6 +273,15 @@ inline void delete_attachment_impl(const std::shared_ptr<database_impl<T> >& db,
 }
 
 template<typename T>
+inline ulonglong wipe_impl(const std::shared_ptr<database_impl<T> >& db)
+{
+    db_writer<T> writer(db);
+    const ulonglong wiped = writer.wipe_free_space();
+    writer.commit();
+    return wiped;
+}
+
+template<typename T>
 inline void delete_folder_contents(db_writer<T>& writer, const std::shared_ptr<database_impl<T> >& db,
                                    node_id folder, const std::vector<node_id>& search)
 {
@@ -341,119 +348,48 @@ inline void delete_folder_impl(const std::shared_ptr<database_impl<T> >& db, nod
     writer.commit();
 }
 
-//! Pick the store's format the way open_database does
-template<typename Unicode, typename Ansi>
-inline void dispatch(const shared_db_ptr& db, Unicode unicode, Ansi ansi)
-{
-    if(std::shared_ptr<large_pst> large = std::dynamic_pointer_cast<large_pst>(db))
-    {
-        unicode(large);
-        return;
-    }
-
-    if(std::shared_ptr<small_pst> small = std::dynamic_pointer_cast<small_pst>(db))
-    {
-        ansi(small);
-        return;
-    }
-
-    throw invalid_format();
-}
-
-struct delete_message_unicode
-{
-    node_id nid;
-    void operator()(const std::shared_ptr<large_pst>& db) const { delete_message_impl(db, nid); }
-};
-
-struct delete_message_ansi
-{
-    node_id nid;
-    void operator()(const std::shared_ptr<small_pst>& db) const { delete_message_impl(db, nid); }
-};
-
-struct delete_attachment_unicode
-{
-    node_id message;
-    node_id attachment;
-    void operator()(const std::shared_ptr<large_pst>& db) const
-        { delete_attachment_impl(db, message, attachment); }
-};
-
-struct delete_attachment_ansi
-{
-    node_id message;
-    node_id attachment;
-    void operator()(const std::shared_ptr<small_pst>& db) const
-        { delete_attachment_impl(db, message, attachment); }
-};
-
-struct wipe_unicode
-{
-    ulonglong* wiped;
-    void operator()(const std::shared_ptr<large_pst>& db) const
-    {
-        db_writer<ulonglong> writer(db);
-        *wiped = writer.wipe_free_space();
-        writer.commit();
-    }
-};
-
-struct wipe_ansi
-{
-    ulonglong* wiped;
-    void operator()(const std::shared_ptr<small_pst>& db) const
-    {
-        db_writer<ulong> writer(db);
-        *wiped = writer.wipe_free_space();
-        writer.commit();
-    }
-};
-
-struct delete_folder_unicode
-{
-    node_id nid;
-    void operator()(const std::shared_ptr<large_pst>& db) const { delete_folder_impl(db, nid); }
-};
-
-struct delete_folder_ansi
-{
-    node_id nid;
-    void operator()(const std::shared_ptr<small_pst>& db) const { delete_folder_impl(db, nid); }
-};
-
 } // end detail namespace
 } // end pstsdk namespace
 
 inline void pstsdk::delete_message(const shared_db_ptr& db, node_id nid)
 {
-    detail::delete_message_unicode unicode = { nid };
-    detail::delete_message_ansi ansi = { nid };
-    detail::dispatch(db, unicode, ansi);
+    if(std::shared_ptr<large_pst> large = std::dynamic_pointer_cast<large_pst>(db))
+        return detail::delete_message_impl(large, nid);
+    if(std::shared_ptr<small_pst> small = std::dynamic_pointer_cast<small_pst>(db))
+        return detail::delete_message_impl(small, nid);
+
+    throw invalid_format();
 }
 
 inline void pstsdk::delete_attachment(const shared_db_ptr& db, node_id message_nid,
                                       node_id attachment_nid)
 {
-    detail::delete_attachment_unicode unicode = { message_nid, attachment_nid };
-    detail::delete_attachment_ansi ansi = { message_nid, attachment_nid };
-    detail::dispatch(db, unicode, ansi);
+    if(std::shared_ptr<large_pst> large = std::dynamic_pointer_cast<large_pst>(db))
+        return detail::delete_attachment_impl(large, message_nid, attachment_nid);
+    if(std::shared_ptr<small_pst> small = std::dynamic_pointer_cast<small_pst>(db))
+        return detail::delete_attachment_impl(small, message_nid, attachment_nid);
+
+    throw invalid_format();
 }
 
 inline pstsdk::ulonglong pstsdk::wipe_free_space(const shared_db_ptr& db)
 {
-    ulonglong wiped = 0;
-    detail::wipe_unicode unicode = { &wiped };
-    detail::wipe_ansi ansi = { &wiped };
-    detail::dispatch(db, unicode, ansi);
-    return wiped;
+    if(std::shared_ptr<large_pst> large = std::dynamic_pointer_cast<large_pst>(db))
+        return detail::wipe_impl(large);
+    if(std::shared_ptr<small_pst> small = std::dynamic_pointer_cast<small_pst>(db))
+        return detail::wipe_impl(small);
+
+    throw invalid_format();
 }
 
 inline void pstsdk::delete_folder(const shared_db_ptr& db, node_id nid)
 {
-    detail::delete_folder_unicode unicode = { nid };
-    detail::delete_folder_ansi ansi = { nid };
-    detail::dispatch(db, unicode, ansi);
+    if(std::shared_ptr<large_pst> large = std::dynamic_pointer_cast<large_pst>(db))
+        return detail::delete_folder_impl(large, nid);
+    if(std::shared_ptr<small_pst> small = std::dynamic_pointer_cast<small_pst>(db))
+        return detail::delete_folder_impl(small, nid);
+
+    throw invalid_format();
 }
 //! \endcond
 

--- a/pstsdk/pst/delete.h
+++ b/pstsdk/pst/delete.h
@@ -1,0 +1,301 @@
+//! \file
+//! \brief Deleting items from a store, in place
+//!
+//! The caller picks what goes; this decides what that costs structurally. An
+//! item's node is unlinked and everything only it owned is zeroed on disk, its
+//! row comes out of the folder's table, and the folder's counts are corrected.
+//!
+//! These edits are made in place, so the store being edited is the store the
+//! caller loses if something goes wrong. Work on a copy.
+//!
+//! Any node, table, folder or message object held across one of these calls is
+//! stale afterwards and must be reopened.
+//! \ingroup pst
+
+#ifndef PSTSDK_PST_DELETE_H
+#define PSTSDK_PST_DELETE_H
+
+#include <vector>
+
+#include "pstsdk/util/errors.h"
+#include "pstsdk/util/primitives.h"
+
+#include "pstsdk/ndb/writer.h"
+#include "pstsdk/ltp/propbag.h"
+#include "pstsdk/ltp/table.h"
+#include "pstsdk/ltp/writer.h"
+
+#include "pstsdk/mapitags.h"
+
+namespace pstsdk
+{
+
+//! \cond write_api
+
+//! \brief The \ref PR_MESSAGE_FLAGS bit that marks a message read
+//!
+//! Needed because an unread message costs its folder a count in
+//! \ref PR_CONTENT_UNREAD as well as one in \ref PR_CONTENT_COUNT.
+//! \sa [MS-OXCMSG] 2.2.1.6
+const slong mapi_message_read = 0x1;
+
+//! \brief Delete a message and everything hanging off it
+//!
+//! Takes the message's row out of its folder's table, corrects
+//! \ref PR_CONTENT_COUNT and, when the message was unread,
+//! \ref PR_CONTENT_UNREAD, then unlinks the node. Attachments, recipients and
+//! embedded messages live in the message's subnode tree and go with it.
+//! \throws key_not_found<node_id> if the message is not in the store
+//! \param[in] db The store to edit, opened writable
+//! \param[in] nid The message to delete
+//! \ingroup pst_messagerelated
+void delete_message(const shared_db_ptr& db, node_id nid);
+
+//! \brief Delete a folder, its subfolders and everything in them
+//!
+//! Removes the folder's row from its parent's hierarchy table and clears
+//! \ref PR_SUBFOLDERS when it was the last one, then deletes the folder's
+//! property context and its contents, hierarchy and associated contents tables.
+//! \throws key_not_found<node_id> if the folder is not in the store
+//! \param[in] db The store to edit, opened writable
+//! \param[in] nid The folder to delete
+//! \ingroup pst_folderrelated
+void delete_folder(const shared_db_ptr& db, node_id nid);
+
+//! \endcond
+
+} // end pstsdk namespace
+
+//! \cond write_api
+namespace pstsdk
+{
+namespace detail
+{
+
+//! Read a property that may not be there, without disturbing the store
+inline bool try_read_long(const shared_db_ptr& db, node_id nid, prop_id id, slong& value)
+{
+    try
+    {
+        property_bag bag(db->lookup_node(nid));
+        if(!bag.prop_exists(id))
+            return false;
+
+        value = bag.read_prop<slong>(id);
+        return true;
+    }
+    catch(key_not_found<node_id>&)
+    {
+        return false;
+    }
+}
+
+//! The row ids of a table node, or nothing if the table is absent
+inline std::vector<row_id> table_row_ids(const shared_db_ptr& db, node_id nid)
+{
+    std::vector<row_id> rows;
+
+    try
+    {
+        table tc(db->lookup_node(nid));
+        for(size_t i = 0; i < tc.size(); ++i)
+            rows.push_back(tc[i].get_row_id());
+    }
+    catch(key_not_found<node_id>&) { }
+
+    return rows;
+}
+
+inline node_id folder_table(node_id folder, nid_type type)
+{
+    return make_nid(type, get_nid_index(folder));
+}
+
+//! Drop a row from whichever of a folder's two message tables holds it
+template<typename T>
+inline bool remove_message_row(db_writer<T>& writer, node_id folder, node_id message, bool& associated)
+{
+    try
+    {
+        tc_remove_row(writer, folder_table(folder, nid_type_contents_table), message);
+        associated = false;
+        return true;
+    }
+    catch(key_not_found<row_id>&) { }
+    catch(key_not_found<node_id>&) { }
+
+    try
+    {
+        tc_remove_row(writer, folder_table(folder, nid_type_associated_contents_table), message);
+        associated = true;
+        return true;
+    }
+    catch(key_not_found<row_id>&) { }
+    catch(key_not_found<node_id>&) { }
+
+    return false;
+}
+
+template<typename T>
+inline void delete_message_impl(const std::shared_ptr<database_impl<T> >& db, node_id nid)
+{
+    const node_info info = db->lookup_node_info(nid);
+    const node_id folder = info.parent_id;
+
+    // Everything the counts depend on has to be read before the first write,
+    // because a write invalidates the store's cached tree.
+    slong flags = 0;
+    const bool has_flags = try_read_long(db, nid, PR_MESSAGE_FLAGS, flags);
+    const bool unread = has_flags && (flags & mapi_message_read) == 0;
+
+    slong content_count = 0;
+    slong unread_count = 0;
+    slong associated_count = 0;
+    const bool has_content = try_read_long(db, folder, PR_CONTENT_COUNT, content_count);
+    const bool has_unread = try_read_long(db, folder, PR_CONTENT_UNREAD, unread_count);
+    const bool has_associated = try_read_long(db, folder, PR_ASSOC_CONTENT_COUNT, associated_count);
+
+    db_writer<T> writer(db);
+
+    bool associated = false;
+    const bool removed = folder != 0 && remove_message_row(writer, folder, nid, associated);
+
+    if(removed && associated && has_associated && associated_count > 0)
+        pc_set_inline(writer, folder, (prop_id)PR_ASSOC_CONTENT_COUNT, associated_count - 1);
+
+    if(removed && !associated && has_content && content_count > 0)
+        pc_set_inline(writer, folder, (prop_id)PR_CONTENT_COUNT, content_count - 1);
+
+    if(removed && !associated && unread && has_unread && unread_count > 0)
+        pc_set_inline(writer, folder, (prop_id)PR_CONTENT_UNREAD, unread_count - 1);
+
+    writer.delete_node(nid);
+    writer.commit();
+}
+
+template<typename T>
+inline void delete_folder_contents(db_writer<T>& writer, const std::shared_ptr<database_impl<T> >& db,
+                                   node_id folder)
+{
+    const std::vector<row_id> subfolders =
+        table_row_ids(db, folder_table(folder, nid_type_hierarchy_table));
+
+    for(size_t i = 0; i < subfolders.size(); ++i)
+        delete_folder_contents(writer, db, subfolders[i]);
+
+    // The tables go with the folder, so the messages only need their nodes
+    // unlinked; there is no row left to take them out of.
+    const std::vector<row_id> messages =
+        table_row_ids(db, folder_table(folder, nid_type_contents_table));
+    const std::vector<row_id> associated =
+        table_row_ids(db, folder_table(folder, nid_type_associated_contents_table));
+
+    for(size_t i = 0; i < messages.size(); ++i)
+        writer.delete_node(messages[i]);
+
+    for(size_t i = 0; i < associated.size(); ++i)
+        writer.delete_node(associated[i]);
+
+    const nid_type tables[] = { nid_type_contents_table, nid_type_hierarchy_table,
+                                nid_type_associated_contents_table };
+
+    for(size_t i = 0; i < sizeof(tables) / sizeof(tables[0]); ++i)
+    {
+        try { writer.delete_node(folder_table(folder, tables[i])); }
+        catch(key_not_found<node_id>&) { }
+    }
+
+    writer.delete_node(folder);
+}
+
+template<typename T>
+inline void delete_folder_impl(const std::shared_ptr<database_impl<T> >& db, node_id nid)
+{
+    const node_info info = db->lookup_node_info(nid);
+    const node_id parent = info.parent_id;
+
+    const size_t siblings =
+        table_row_ids(db, folder_table(parent, nid_type_hierarchy_table)).size();
+
+    db_writer<T> writer(db);
+
+    if(parent != 0)
+    {
+        try { tc_remove_row(writer, folder_table(parent, nid_type_hierarchy_table), nid); }
+        catch(key_not_found<row_id>&) { }
+        catch(key_not_found<node_id>&) { }
+
+        // the expander in a client reads this flag rather than counting rows
+        if(siblings == 1)
+        {
+            try { pc_set_inline(writer, parent, (prop_id)PR_SUBFOLDERS, 0); }
+            catch(key_not_found<prop_id>&) { }
+        }
+    }
+
+    delete_folder_contents(writer, db, nid);
+    writer.commit();
+}
+
+//! Pick the store's format the way open_database does
+template<typename Unicode, typename Ansi>
+inline void dispatch(const shared_db_ptr& db, Unicode unicode, Ansi ansi)
+{
+    if(std::shared_ptr<large_pst> large = std::dynamic_pointer_cast<large_pst>(db))
+    {
+        unicode(large);
+        return;
+    }
+
+    if(std::shared_ptr<small_pst> small = std::dynamic_pointer_cast<small_pst>(db))
+    {
+        ansi(small);
+        return;
+    }
+
+    throw invalid_format();
+}
+
+struct delete_message_unicode
+{
+    node_id nid;
+    void operator()(const std::shared_ptr<large_pst>& db) const { delete_message_impl(db, nid); }
+};
+
+struct delete_message_ansi
+{
+    node_id nid;
+    void operator()(const std::shared_ptr<small_pst>& db) const { delete_message_impl(db, nid); }
+};
+
+struct delete_folder_unicode
+{
+    node_id nid;
+    void operator()(const std::shared_ptr<large_pst>& db) const { delete_folder_impl(db, nid); }
+};
+
+struct delete_folder_ansi
+{
+    node_id nid;
+    void operator()(const std::shared_ptr<small_pst>& db) const { delete_folder_impl(db, nid); }
+};
+
+} // end detail namespace
+} // end pstsdk namespace
+
+inline void pstsdk::delete_message(const shared_db_ptr& db, node_id nid)
+{
+    detail::delete_message_unicode unicode = { nid };
+    detail::delete_message_ansi ansi = { nid };
+    detail::dispatch(db, unicode, ansi);
+}
+
+inline void pstsdk::delete_folder(const shared_db_ptr& db, node_id nid)
+{
+    detail::delete_folder_unicode unicode = { nid };
+    detail::delete_folder_ansi ansi = { nid };
+    detail::dispatch(db, unicode, ansi);
+}
+//! \endcond
+
+#endif

--- a/pstsdk/pst/delete.h
+++ b/pstsdk/pst/delete.h
@@ -15,6 +15,7 @@
 #ifndef PSTSDK_PST_DELETE_H
 #define PSTSDK_PST_DELETE_H
 
+#include <set>
 #include <vector>
 
 #include "pstsdk/util/errors.h"
@@ -283,13 +284,18 @@ inline ulonglong wipe_impl(const std::shared_ptr<database_impl<T> >& db)
 
 template<typename T>
 inline void delete_folder_contents(db_writer<T>& writer, const std::shared_ptr<database_impl<T> >& db,
-                                   node_id folder, const std::vector<node_id>& search)
+                                   node_id folder, const std::vector<node_id>& search,
+                                   std::set<node_id>& seen)
 {
+    // a hierarchy table naming an ancestor would otherwise recurse forever
+    if(!seen.insert(folder).second)
+        return;
+
     const std::vector<row_id> subfolders =
         table_row_ids(db, folder_table(folder, nid_type_hierarchy_table));
 
     for(size_t i = 0; i < subfolders.size(); ++i)
-        delete_folder_contents(writer, db, subfolders[i], search);
+        delete_folder_contents(writer, db, subfolders[i], search, seen);
 
     // The tables go with the folder, so the messages only need their nodes
     // unlinked; there is no row left to take them out of.
@@ -301,11 +307,15 @@ inline void delete_folder_contents(db_writer<T>& writer, const std::shared_ptr<d
     for(size_t i = 0; i < messages.size(); ++i)
     {
         sweep_search_folders(writer, search, (node_id)messages[i]);
-        writer.delete_node(messages[i]);
+        try { writer.delete_node(messages[i]); }
+        catch(key_not_found<node_id>&) { }
     }
 
     for(size_t i = 0; i < associated.size(); ++i)
-        writer.delete_node(associated[i]);
+    {
+        try { writer.delete_node(associated[i]); }
+        catch(key_not_found<node_id>&) { }
+    }
 
     const nid_type tables[] = { nid_type_contents_table, nid_type_hierarchy_table,
                                 nid_type_associated_contents_table };
@@ -316,7 +326,8 @@ inline void delete_folder_contents(db_writer<T>& writer, const std::shared_ptr<d
         catch(key_not_found<node_id>&) { }
     }
 
-    writer.delete_node(folder);
+    try { writer.delete_node(folder); }
+    catch(key_not_found<node_id>&) { }
 }
 
 template<typename T>
@@ -344,7 +355,8 @@ inline void delete_folder_impl(const std::shared_ptr<database_impl<T> >& db, nod
         }
     }
 
-    delete_folder_contents(writer, db, nid, search);
+    std::set<node_id> seen;
+    delete_folder_contents(writer, db, nid, search, seen);
     writer.commit();
 }
 

--- a/pstsdk/pst/delete.h
+++ b/pstsdk/pst/delete.h
@@ -365,10 +365,10 @@ inline void delete_folder_impl(const std::shared_ptr<database_impl<T> >& db, nod
 
 inline void pstsdk::delete_message(const shared_db_ptr& db, node_id nid)
 {
-    if(std::shared_ptr<large_pst> large = std::dynamic_pointer_cast<large_pst>(db))
-        return detail::delete_message_impl(large, nid);
-    if(std::shared_ptr<small_pst> small = std::dynamic_pointer_cast<small_pst>(db))
-        return detail::delete_message_impl(small, nid);
+    if(std::shared_ptr<large_pst> unicode = std::dynamic_pointer_cast<large_pst>(db))
+        return detail::delete_message_impl(unicode, nid);
+    if(std::shared_ptr<small_pst> ansi = std::dynamic_pointer_cast<small_pst>(db))
+        return detail::delete_message_impl(ansi, nid);
 
     throw invalid_format();
 }
@@ -376,30 +376,30 @@ inline void pstsdk::delete_message(const shared_db_ptr& db, node_id nid)
 inline void pstsdk::delete_attachment(const shared_db_ptr& db, node_id message_nid,
                                       node_id attachment_nid)
 {
-    if(std::shared_ptr<large_pst> large = std::dynamic_pointer_cast<large_pst>(db))
-        return detail::delete_attachment_impl(large, message_nid, attachment_nid);
-    if(std::shared_ptr<small_pst> small = std::dynamic_pointer_cast<small_pst>(db))
-        return detail::delete_attachment_impl(small, message_nid, attachment_nid);
+    if(std::shared_ptr<large_pst> unicode = std::dynamic_pointer_cast<large_pst>(db))
+        return detail::delete_attachment_impl(unicode, message_nid, attachment_nid);
+    if(std::shared_ptr<small_pst> ansi = std::dynamic_pointer_cast<small_pst>(db))
+        return detail::delete_attachment_impl(ansi, message_nid, attachment_nid);
 
     throw invalid_format();
 }
 
 inline pstsdk::ulonglong pstsdk::wipe_free_space(const shared_db_ptr& db)
 {
-    if(std::shared_ptr<large_pst> large = std::dynamic_pointer_cast<large_pst>(db))
-        return detail::wipe_impl(large);
-    if(std::shared_ptr<small_pst> small = std::dynamic_pointer_cast<small_pst>(db))
-        return detail::wipe_impl(small);
+    if(std::shared_ptr<large_pst> unicode = std::dynamic_pointer_cast<large_pst>(db))
+        return detail::wipe_impl(unicode);
+    if(std::shared_ptr<small_pst> ansi = std::dynamic_pointer_cast<small_pst>(db))
+        return detail::wipe_impl(ansi);
 
     throw invalid_format();
 }
 
 inline void pstsdk::delete_folder(const shared_db_ptr& db, node_id nid)
 {
-    if(std::shared_ptr<large_pst> large = std::dynamic_pointer_cast<large_pst>(db))
-        return detail::delete_folder_impl(large, nid);
-    if(std::shared_ptr<small_pst> small = std::dynamic_pointer_cast<small_pst>(db))
-        return detail::delete_folder_impl(small, nid);
+    if(std::shared_ptr<large_pst> unicode = std::dynamic_pointer_cast<large_pst>(db))
+        return detail::delete_folder_impl(unicode, nid);
+    if(std::shared_ptr<small_pst> ansi = std::dynamic_pointer_cast<small_pst>(db))
+        return detail::delete_folder_impl(ansi, nid);
 
     throw invalid_format();
 }

--- a/pstsdk/pst/delete.h
+++ b/pstsdk/pst/delete.h
@@ -51,6 +51,18 @@ const slong mapi_message_read = 0x1;
 //! \ingroup pst_messagerelated
 void delete_message(const shared_db_ptr& db, node_id nid);
 
+//! \brief Delete one attachment, leaving the message in place
+//!
+//! Takes the attachment's row out of the message's attachment table, drops its
+//! subnode and everything that hung off it including an embedded message, and
+//! clears \ref PR_HASATTACH when it was the last one.
+//! \throws key_not_found<node_id> if the message or attachment is not there
+//! \param[in] db The store to edit, opened writable
+//! \param[in] message_nid The message owning the attachment
+//! \param[in] attachment_nid The attachment's subnode id
+//! \ingroup pst_messagerelated
+void delete_attachment(const shared_db_ptr& db, node_id message_nid, node_id attachment_nid);
+
 //! \brief Delete a folder, its subfolders and everything in them
 //!
 //! Removes the folder's row from its parent's hierarchy table and clears
@@ -106,6 +118,18 @@ inline std::vector<row_id> table_row_ids(const shared_db_ptr& db, node_id nid)
     return rows;
 }
 
+//! The row ids of a table carried by one of a node's subnodes
+inline std::vector<row_id> table_row_ids(const shared_db_ptr& db, node_id owner, node_id sub)
+{
+    std::vector<row_id> rows;
+
+    table tc(db->lookup_node(owner).lookup(sub));
+    for(size_t i = 0; i < tc.size(); ++i)
+        rows.push_back(tc[i].get_row_id());
+
+    return rows;
+}
+
 inline node_id folder_table(node_id folder, nid_type type)
 {
     return make_nid(type, get_nid_index(folder));
@@ -122,7 +146,6 @@ inline bool remove_message_row(db_writer<T>& writer, node_id folder, node_id mes
         return true;
     }
     catch(key_not_found<row_id>&) { }
-    catch(key_not_found<node_id>&) { }
 
     try
     {
@@ -131,7 +154,6 @@ inline bool remove_message_row(db_writer<T>& writer, node_id folder, node_id mes
         return true;
     }
     catch(key_not_found<row_id>&) { }
-    catch(key_not_found<node_id>&) { }
 
     return false;
 }
@@ -170,6 +192,37 @@ inline void delete_message_impl(const std::shared_ptr<database_impl<T> >& db, no
         pc_set_inline(writer, folder, (prop_id)PR_CONTENT_UNREAD, unread_count - 1);
 
     writer.delete_node(nid);
+    writer.commit();
+}
+
+template<typename T>
+inline void delete_attachment_impl(const std::shared_ptr<database_impl<T> >& db,
+                                   node_id message_nid, node_id attachment_nid)
+{
+    db_writer<T> writer(db);
+    const typename db_writer<T>::data_ref message = writer.node_ref(message_nid);
+
+    if(message.sub == 0)
+        throw key_not_found<node_id>(attachment_nid);
+
+    const typename db_writer<T>::data_ref table =
+        writer.subnode_ref(message.sub, nid_attachment_table);
+
+    tc_remove_row(writer, table, attachment_nid);
+    writer.subnode_remove(message.sub, attachment_nid);
+
+    // the table survives with no rows, the way a message that never had an
+    // attachment carries one, so the flag is what a client actually reads
+    size_t left = 0;
+    try { left = table_row_ids(db, message_nid, nid_attachment_table).size(); }
+    catch(key_not_found<node_id>&) { }
+
+    if(left == 0)
+    {
+        try { pc_set_inline(writer, message_nid, (prop_id)PR_HASATTACH, 0); }
+        catch(key_not_found<prop_id>&) { }
+    }
+
     writer.commit();
 }
 
@@ -223,7 +276,6 @@ inline void delete_folder_impl(const std::shared_ptr<database_impl<T> >& db, nod
     {
         try { tc_remove_row(writer, folder_table(parent, nid_type_hierarchy_table), nid); }
         catch(key_not_found<row_id>&) { }
-        catch(key_not_found<node_id>&) { }
 
         // the expander in a client reads this flag rather than counting rows
         if(siblings == 1)
@@ -268,6 +320,22 @@ struct delete_message_ansi
     void operator()(const std::shared_ptr<small_pst>& db) const { delete_message_impl(db, nid); }
 };
 
+struct delete_attachment_unicode
+{
+    node_id message;
+    node_id attachment;
+    void operator()(const std::shared_ptr<large_pst>& db) const
+        { delete_attachment_impl(db, message, attachment); }
+};
+
+struct delete_attachment_ansi
+{
+    node_id message;
+    node_id attachment;
+    void operator()(const std::shared_ptr<small_pst>& db) const
+        { delete_attachment_impl(db, message, attachment); }
+};
+
 struct delete_folder_unicode
 {
     node_id nid;
@@ -287,6 +355,14 @@ inline void pstsdk::delete_message(const shared_db_ptr& db, node_id nid)
 {
     detail::delete_message_unicode unicode = { nid };
     detail::delete_message_ansi ansi = { nid };
+    detail::dispatch(db, unicode, ansi);
+}
+
+inline void pstsdk::delete_attachment(const shared_db_ptr& db, node_id message_nid,
+                                      node_id attachment_nid)
+{
+    detail::delete_attachment_unicode unicode = { message_nid, attachment_nid };
+    detail::delete_attachment_ansi ansi = { message_nid, attachment_nid };
     detail::dispatch(db, unicode, ansi);
 }
 

--- a/pstsdk/pst/delete.h
+++ b/pstsdk/pst/delete.h
@@ -74,6 +74,16 @@ void delete_attachment(const shared_db_ptr& db, node_id message_nid, node_id att
 //! \ingroup pst_folderrelated
 void delete_folder(const shared_db_ptr& db, node_id nid);
 
+//! \brief Zero every byte the store does not reference
+//!
+//! Deleting an item clears what that item owned. This clears everything else the
+//! store is not using, including text left in free space by whatever client
+//! deleted things before the file reached you. Run it after the deletes.
+//! \param[in] db The store to edit, opened writable
+//! \returns The number of bytes zeroed
+//! \ingroup pst
+ulonglong wipe_free_space(const shared_db_ptr& db);
+
 //! \endcond
 
 } // end pstsdk namespace
@@ -378,6 +388,28 @@ struct delete_attachment_ansi
         { delete_attachment_impl(db, message, attachment); }
 };
 
+struct wipe_unicode
+{
+    ulonglong* wiped;
+    void operator()(const std::shared_ptr<large_pst>& db) const
+    {
+        db_writer<ulonglong> writer(db);
+        *wiped = writer.wipe_free_space();
+        writer.commit();
+    }
+};
+
+struct wipe_ansi
+{
+    ulonglong* wiped;
+    void operator()(const std::shared_ptr<small_pst>& db) const
+    {
+        db_writer<ulong> writer(db);
+        *wiped = writer.wipe_free_space();
+        writer.commit();
+    }
+};
+
 struct delete_folder_unicode
 {
     node_id nid;
@@ -406,6 +438,15 @@ inline void pstsdk::delete_attachment(const shared_db_ptr& db, node_id message_n
     detail::delete_attachment_unicode unicode = { message_nid, attachment_nid };
     detail::delete_attachment_ansi ansi = { message_nid, attachment_nid };
     detail::dispatch(db, unicode, ansi);
+}
+
+inline pstsdk::ulonglong pstsdk::wipe_free_space(const shared_db_ptr& db)
+{
+    ulonglong wiped = 0;
+    detail::wipe_unicode unicode = { &wiped };
+    detail::wipe_ansi ansi = { &wiped };
+    detail::dispatch(db, unicode, ansi);
+    return wiped;
 }
 
 inline void pstsdk::delete_folder(const shared_db_ptr& db, node_id nid)

--- a/pstsdk/util/errors.h
+++ b/pstsdk/util/errors.h
@@ -42,9 +42,21 @@ public:
         : runtime_error(error) { }
 };
 
+//! \brief An edit was attempted on a block with more than one reference.
+//!
+//! In place edits have nowhere to copy a shared block to, so the caller has to
+//! either unlink it instead or leave it alone.
+//! \ingroup exception
+class shared_block : public std::runtime_error
+{
+public:
+    explicit shared_block(const std::string& error)
+        : runtime_error(error) { }
+};
+
 //! \brief The database is corrupt.
 //! \ingroup exception
-class database_corrupt : public std::runtime_error 
+class database_corrupt : public std::runtime_error
 {
 public:
     explicit database_corrupt(const std::string& error)

--- a/pstsdk/util/errors.h
+++ b/pstsdk/util/errors.h
@@ -56,7 +56,7 @@ public:
 
 //! \brief The database is corrupt.
 //! \ingroup exception
-class database_corrupt : public std::runtime_error
+class database_corrupt : public std::runtime_error 
 {
 public:
     explicit database_corrupt(const std::string& error)

--- a/pstsdk/util/util.h
+++ b/pstsdk/util/util.h
@@ -47,7 +47,8 @@ public:
     //! \brief Construct a file object from the given filename
     //! \throw runtime_error if an error occurs opening the file
     //! \param[in] filename The file to open
-    file(const std::wstring& filename);
+    //! \param[in] writable Open for update, so \ref write can be used
+    file(const std::wstring& filename, bool writable = false);
     
     //! \brief Close the file
     ~file();
@@ -142,10 +143,12 @@ std::vector<byte> wstring_to_bytes(const std::wstring &wstr);
 
 } // end pstsdk namespace
 
-inline pstsdk::file::file(const std::wstring& filename)
+inline pstsdk::file::file(const std::wstring& filename, bool writable)
 : m_filename(filename)
 {
-    const char* mode = "rb";
+    // "r+b" rather than "w+b": every write in this library is an in-place edit of
+    // an existing store, so truncating on open would destroy it.
+    const char* mode = writable ? "r+b" : "rb";
 
 #ifdef _MSC_VER 
     errno_t err = fopen_s(&m_pfile, std::string(filename.begin(), filename.end()).c_str(), mode);

--- a/pstsdk/util/util.h
+++ b/pstsdk/util/util.h
@@ -26,6 +26,10 @@
 #include <windows.h>
 #endif
 
+#ifdef _MSC_VER
+#include <share.h>
+#endif
+
 namespace pstsdk
 {
 
@@ -150,10 +154,10 @@ inline pstsdk::file::file(const std::wstring& filename, bool writable)
     // an existing store, so truncating on open would destroy it.
     const char* mode = writable ? "r+b" : "rb";
 
-#ifdef _MSC_VER 
-    errno_t err = fopen_s(&m_pfile, std::string(filename.begin(), filename.end()).c_str(), mode);
-    if(err != 0)
-        m_pfile = NULL;
+#ifdef _MSC_VER
+    // not fopen_s: it opens exclusively, so a second handle on the same store
+    // fails, and both this library and its callers open one store more than once
+    m_pfile = _fsopen(std::string(filename.begin(), filename.end()).c_str(), mode, _SH_DENYNO);
 #else
     m_pfile = fopen(std::string(filename.begin(), filename.end()).c_str(), mode);
 #endif

--- a/pstsdk/util/util.h
+++ b/pstsdk/util/util.h
@@ -204,6 +204,10 @@ inline size_t pstsdk::file::write(const std::vector<byte>& buffer, ulonglong off
     if(write != buffer.size())
         throw std::out_of_range("fwrite failed");
 
+    // another handle on this file has its own buffer, and on Windows those are
+    // not coherent with this one until the bytes actually land
+    fflush(m_pfile);
+
     return write;
 }
 //! \endcond

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,3 +6,4 @@ if(Iconv_FOUND)
 endif()
 
 add_test(NAME pstsdk_test COMMAND pstsdk_test WORKING_DIRECTORY ../test)
+set_tests_properties(pstsdk_test PROPERTIES TIMEOUT 900)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,4 +6,4 @@ if(Iconv_FOUND)
 endif()
 
 add_test(NAME pstsdk_test COMMAND pstsdk_test WORKING_DIRECTORY ../test)
-set_tests_properties(pstsdk_test PROPERTIES TIMEOUT 900)
+set_tests_properties(pstsdk_test PROPERTIES TIMEOUT 300)

--- a/test/deletetest.cpp
+++ b/test/deletetest.cpp
@@ -31,6 +31,35 @@ std::wstring copy_sample(const std::string& sample, const std::string& tag)
     return widen(copy);
 }
 
+// Owns the working copy and removes it on the way out. Declare it before any
+// handle on the file: destruction runs in reverse, so the handles close first,
+// and Windows will not unlink a file that is still open.
+class scratch_file
+{
+public:
+    scratch_file(const std::string& sample, const std::string& tag)
+        : m_path(copy_sample(sample, tag)) { }
+
+    //! A copy beside the original, for stores that live outside test/
+    scratch_file(const std::string& source, const std::string& suffix, bool beside)
+        : m_path(widen(source + suffix))
+    {
+        (void)beside;
+        std::filesystem::copy_file(source, narrow(m_path),
+                                   std::filesystem::copy_options::overwrite_existing);
+    }
+
+    ~scratch_file() { std::filesystem::remove(narrow(m_path)); }
+
+    const std::wstring& path() const { return m_path; }
+
+private:
+    scratch_file(const scratch_file&);
+    scratch_file& operator=(const scratch_file&);
+
+    std::wstring m_path;
+};
+
 std::vector<pstsdk::byte> slurp(const std::wstring& path)
 {
     std::ifstream in(narrow(path), std::ios::binary);
@@ -58,7 +87,8 @@ void test_block_roundtrip(const std::string& sample)
 {
     using namespace pstsdk;
 
-    std::wstring path = copy_sample(sample, "roundtrip");
+    scratch_file scratch(sample, "roundtrip");
+    const std::wstring& path = scratch.path();
     std::vector<byte> before = slurp(path);
     size_t shared = 0;
 
@@ -115,7 +145,6 @@ void test_block_roundtrip(const std::string& sample)
         assert(std::dynamic_pointer_cast<database_impl<T> >(db));
     }
 
-    std::filesystem::remove(narrow(path));
 }
 
 // Shrinking is the only resize write_block allows, and the interesting case is a
@@ -126,7 +155,8 @@ void test_block_shrink(const std::string& sample)
 {
     using namespace pstsdk;
 
-    std::wstring path = copy_sample(sample, "shrink");
+    scratch_file scratch(sample, "shrink");
+    const std::wstring& path = scratch.path();
     size_t shrunk = 0;
 
     {
@@ -178,7 +208,6 @@ void test_block_shrink(const std::string& sample)
     }
 
     assert(shrunk > 0);
-    std::filesystem::remove(narrow(path));
 }
 
 std::vector<pstsdk::node_id> all_nids(const pstsdk::shared_db_ptr& db)
@@ -252,7 +281,8 @@ void test_nbt_remove(const std::string& sample)
 
     for(size_t victim = 0; victim < original.size(); ++victim)
     {
-        std::wstring path = copy_sample(sample, "nbtremove");
+        scratch_file scratch(sample, "nbtremove");
+    const std::wstring& path = scratch.path();
 
         {
             std::shared_ptr<file> f(new file(path, true));
@@ -288,7 +318,6 @@ void test_nbt_remove(const std::string& sample)
         assert(missing);
 
         db.reset();
-        std::filesystem::remove(narrow(path));
     }
 }
 
@@ -300,7 +329,8 @@ void test_nbt_drain(const std::string& sample)
 {
     using namespace pstsdk;
 
-    std::wstring path = copy_sample(sample, "nbtdrain");
+    scratch_file scratch(sample, "nbtdrain");
+    const std::wstring& path = scratch.path();
     std::vector<node_id> nids;
     ulonglong root;
 
@@ -340,7 +370,6 @@ void test_nbt_drain(const std::string& sample)
     check_bt_page<T>(check, root, keys);
     assert(keys.size() == 1);
 
-    std::filesystem::remove(narrow(path));
 }
 
 std::map<pstsdk::block_id, pstsdk::block_info> bbt_snapshot(const pstsdk::shared_db_ptr& db)
@@ -490,7 +519,8 @@ void test_delete_node(const std::string& sample)
 
     for(size_t victim = 0; victim < nids.size(); ++victim)
     {
-        std::wstring path = copy_sample(sample, "delnode");
+        scratch_file scratch(sample, "delnode");
+    const std::wstring& path = scratch.path();
 
         std::map<block_id, block_info> before;
         {
@@ -539,7 +569,6 @@ void test_delete_node(const std::string& sample)
         check_refcounts<T>(db, path);
 
         db.reset();
-        std::filesystem::remove(narrow(path));
     }
 
     assert(scrubbed > 0);
@@ -554,7 +583,8 @@ void test_pc_set_inline(const std::string& sample)
 {
     using namespace pstsdk;
 
-    std::wstring path = copy_sample(sample, "pcinline");
+    scratch_file scratch(sample, "pcinline");
+    const std::wstring& path = scratch.path();
     node_id folder = 0;
 
     {
@@ -592,7 +622,6 @@ void test_pc_set_inline(const std::string& sample)
     check_refcounts<T>(db, path);
 
     db.reset();
-    std::filesystem::remove(narrow(path));
 }
 
 std::vector<pstsdk::row_id> table_rows(const pstsdk::node& owner, pstsdk::node_id sub)
@@ -736,7 +765,8 @@ void test_tc_remove_row(const std::string& sample)
 
         for(size_t victim = 0; victim < original.size(); ++victim)
         {
-            std::wstring path = copy_sample(sample, "tcrow");
+            scratch_file scratch(sample, "tcrow");
+    const std::wstring& path = scratch.path();
 
             {
                 std::shared_ptr<file> f(new file(path, true));
@@ -767,7 +797,6 @@ void test_tc_remove_row(const std::string& sample)
             check_row_index(db, tables[t].first);
 
             db.reset();
-            std::filesystem::remove(narrow(path));
         }
     }
 
@@ -888,7 +917,8 @@ void test_delete_message(const std::string& sample)
 
     for(size_t victim = 0; victim < messages.size(); ++victim)
     {
-        std::wstring path = copy_sample(sample, "delmsg");
+        scratch_file scratch(sample, "delmsg");
+    const std::wstring& path = scratch.path();
         const node_id message = messages[victim];
 
         node_id folder = 0;
@@ -956,7 +986,6 @@ void test_delete_message(const std::string& sample)
         db.reset();
 
         walk_store(path);
-        std::filesystem::remove(narrow(path));
     }
 }
 
@@ -981,7 +1010,8 @@ void test_delete_folder(const std::string& sample)
 
     for(size_t victim = 0; victim < folders.size(); ++victim)
     {
-        std::wstring path = copy_sample(sample, "delfolder");
+        scratch_file scratch(sample, "delfolder");
+    const std::wstring& path = scratch.path();
         const node_id target = folders[victim];
 
         node_id parent = 0;
@@ -1032,7 +1062,6 @@ void test_delete_folder(const std::string& sample)
         db.reset();
 
         walk_store(path);
-        std::filesystem::remove(narrow(path));
     }
 }
 
@@ -1071,7 +1100,8 @@ void test_delete_attachment(const std::string& sample)
 
         for(size_t victim = 0; victim < all.size(); ++victim)
         {
-            std::wstring path = copy_sample(sample, "delatt");
+            scratch_file scratch(sample, "delatt");
+    const std::wstring& path = scratch.path();
 
             {
                 std::shared_ptr<file> f(new file(path, true));
@@ -1113,7 +1143,6 @@ void test_delete_attachment(const std::string& sample)
             db.reset();
 
             walk_store(path);
-            std::filesystem::remove(narrow(path));
         }
     }
 
@@ -1128,7 +1157,8 @@ void test_wipe_free_space(const std::string& sample, const std::wstring& text)
 {
     using namespace pstsdk;
 
-    std::wstring path = copy_sample(sample, "wipe");
+    scratch_file scratch(sample, "wipe");
+    const std::wstring& path = scratch.path();
     const std::vector<byte> needle = encoded_needle(text);
     assert(count_occurrences(slurp(path), needle) > 0);
 
@@ -1171,7 +1201,6 @@ void test_wipe_free_space(const std::string& sample, const std::wstring& text)
     db.reset();
 
     walk_store(path);
-    std::filesystem::remove(narrow(path));
 }
 
 // Every store under test/ keeps its row matrices inline, so nothing here reaches
@@ -1187,9 +1216,8 @@ void drain_store(const std::string& source)
 {
     using namespace pstsdk;
 
-    const std::wstring path = widen(source + ".draining");
-    std::filesystem::copy_file(source, narrow(path),
-                               std::filesystem::copy_options::overwrite_existing);
+    scratch_file scratch(source, ".draining", true);
+    const std::wstring& path = scratch.path();
 
     size_t deleted = 0;
 
@@ -1243,7 +1271,6 @@ void drain_store(const std::string& source)
     std::wcout << L"  drained " << deleted << L" messages from "
                << widen(source) << std::endl;
 
-    std::filesystem::remove(narrow(path));
 }
 
 // Strips every attachment from every message, then confirms the messages are all
@@ -1255,9 +1282,8 @@ void strip_attachments(const std::string& source)
 {
     using namespace pstsdk;
 
-    const std::wstring path = widen(source + ".stripping");
-    std::filesystem::copy_file(source, narrow(path),
-                               std::filesystem::copy_options::overwrite_existing);
+    scratch_file scratch(source, ".stripping", true);
+    const std::wstring& path = scratch.path();
 
     size_t removed = 0;
     size_t messages = 0;
@@ -1326,7 +1352,6 @@ void strip_attachments(const std::string& source)
     std::wcout << L"  stripped " << removed << L" attachments from "
                << widen(source) << L", " << messages << L" messages intact" << std::endl;
 
-    std::filesystem::remove(narrow(path));
 }
 
 void test_corpus()

--- a/test/deletetest.cpp
+++ b/test/deletetest.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <iterator>
 #include <map>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -372,20 +373,27 @@ std::vector<pstsdk::byte> read_raw_block(pstsdk::file& f,
 
 template<typename T>
 void count_subnode_tree(pstsdk::file& f, const std::map<pstsdk::block_id, pstsdk::block_info>& bbt,
-                        pstsdk::block_id bid, std::map<pstsdk::block_id, unsigned>& refs);
+                        pstsdk::block_id bid, std::map<pstsdk::block_id, unsigned>& refs,
+                        std::set<pstsdk::block_id>& seen);
 
 template<typename T>
 void count_data_tree(pstsdk::file& f, const std::map<pstsdk::block_id, pstsdk::block_info>& bbt,
-                     pstsdk::block_id bid, std::map<pstsdk::block_id, unsigned>& refs)
+                     pstsdk::block_id bid, std::map<pstsdk::block_id, unsigned>& refs,
+                     std::set<pstsdk::block_id>& seen)
 {
     using namespace pstsdk;
 
     if(bid == 0)
         return;
 
-    ++refs[bid & ~block_id(disk::block_id_attached_bit)];
+    const block_id key = bid & ~block_id(disk::block_id_attached_bit);
+    ++refs[key];
 
     if(disk::bid_is_external(bid))
+        return;
+
+    // count every edge, but walk a shared block's contents only once
+    if(!seen.insert(key).second)
         return;
 
     std::vector<byte> raw = read_raw_block<T>(f, bbt, bid);
@@ -393,19 +401,24 @@ void count_data_tree(pstsdk::file& f, const std::map<pstsdk::block_id, pstsdk::b
         reinterpret_cast<const disk::extended_block<T>*>(&raw[0]);
 
     for(pstsdk::ushort i = 0; i < xblock->count; ++i)
-        count_data_tree<T>(f, bbt, xblock->bid[i], refs);
+        count_data_tree<T>(f, bbt, xblock->bid[i], refs, seen);
 }
 
 template<typename T>
 void count_subnode_tree(pstsdk::file& f, const std::map<pstsdk::block_id, pstsdk::block_info>& bbt,
-                        pstsdk::block_id bid, std::map<pstsdk::block_id, unsigned>& refs)
+                        pstsdk::block_id bid, std::map<pstsdk::block_id, unsigned>& refs,
+                        std::set<pstsdk::block_id>& seen)
 {
     using namespace pstsdk;
 
     if(bid == 0)
         return;
 
-    ++refs[bid & ~block_id(disk::block_id_attached_bit)];
+    const block_id key = bid & ~block_id(disk::block_id_attached_bit);
+    ++refs[key];
+
+    if(!seen.insert(key).second)
+        return;
 
     std::vector<byte> raw = read_raw_block<T>(f, bbt, bid);
     const disk::sub_block<T, disk::sub_leaf_entry<T> >* leaf =
@@ -415,8 +428,8 @@ void count_subnode_tree(pstsdk::file& f, const std::map<pstsdk::block_id, pstsdk
     {
         for(pstsdk::ushort i = 0; i < leaf->count; ++i)
         {
-            count_data_tree<T>(f, bbt, leaf->entry[i].data, refs);
-            count_subnode_tree<T>(f, bbt, leaf->entry[i].sub, refs);
+            count_data_tree<T>(f, bbt, leaf->entry[i].data, refs, seen);
+            count_subnode_tree<T>(f, bbt, leaf->entry[i].sub, refs, seen);
         }
 
         return;
@@ -426,7 +439,7 @@ void count_subnode_tree(pstsdk::file& f, const std::map<pstsdk::block_id, pstsdk
         reinterpret_cast<const disk::sub_block<T, disk::sub_nonleaf_entry<T> >*>(&raw[0]);
 
     for(pstsdk::ushort i = 0; i < nonleaf->count; ++i)
-        count_subnode_tree<T>(f, bbt, nonleaf->entry[i].sub_block_bid, refs);
+        count_subnode_tree<T>(f, bbt, nonleaf->entry[i].sub_block_bid, refs, seen);
 }
 
 // Rebuilds the true reference graph from the NBT down and holds the BBT to it.
@@ -439,13 +452,14 @@ void check_refcounts(const pstsdk::shared_db_ptr& db, const std::wstring& path)
 
     std::map<block_id, block_info> bbt = bbt_snapshot(db);
     std::map<block_id, unsigned> refs;
+    std::set<block_id> seen;
     file f(path);
 
     std::shared_ptr<nbt_page> root = db->read_nbt_root();
     for(const_nodeinfo_iterator i = root->begin(); i != root->end(); ++i)
     {
-        count_data_tree<T>(f, bbt, (*i).data_bid, refs);
-        count_subnode_tree<T>(f, bbt, (*i).sub_bid, refs);
+        count_data_tree<T>(f, bbt, (*i).data_bid, refs, seen);
+        count_subnode_tree<T>(f, bbt, (*i).sub_bid, refs, seen);
     }
 
     for(std::map<block_id, block_info>::const_iterator i = bbt.begin(); i != bbt.end(); ++i)
@@ -781,6 +795,53 @@ void walk_store(const std::wstring& path)
     }
 }
 
+// The permute-encoded form of a string, which is how it actually sits on disk
+std::vector<pstsdk::byte> encoded_needle(const std::wstring& text)
+{
+    using namespace pstsdk;
+
+    std::vector<byte> raw;
+    for(size_t i = 0; i < text.size(); ++i)
+    {
+        raw.push_back((byte)(text[i] & 0xff));
+        raw.push_back((byte)((text[i] >> 8) & 0xff));
+    }
+
+    if(!raw.empty())
+        disk::permute(&raw[0], (pstsdk::ulong)raw.size(), true);
+
+    return raw;
+}
+
+// Occurrences that land inside a block the store still references. Free space is
+// deliberately excluded: real stores already carry stale plaintext there from
+// whatever the original client deleted, and an in place edit does not clear it.
+size_t count_in_live_blocks(const std::vector<pstsdk::byte>& hay,
+                            const std::vector<pstsdk::byte>& needle,
+                            const std::map<pstsdk::block_id, pstsdk::block_info>& bbt)
+{
+    using namespace pstsdk;
+
+    if(needle.empty() || hay.size() < needle.size())
+        return 0;
+
+    size_t hits = 0;
+    for(size_t i = 0; i + needle.size() <= hay.size(); ++i)
+    {
+        if(memcmp(&hay[i], &needle[0], needle.size()) != 0)
+            continue;
+
+        for(std::map<block_id, block_info>::const_iterator b = bbt.begin(); b != bbt.end(); ++b)
+            if(i >= b->second.address && i < b->second.address + b->second.size)
+            {
+                ++hits;
+                break;
+            }
+    }
+
+    return hits;
+}
+
 // Deletes every message in the store, one per copy, through the public entry
 // point. This is the first test that holds the whole stack to account at once:
 // the node is gone, the folder's row and count agree, the row index still lines
@@ -807,9 +868,29 @@ void test_delete_message(const std::string& sample)
         const node_id message = messages[victim];
 
         node_id folder = 0;
+        std::wstring subject;
+        bool unique_subject = false;
         {
             shared_db_ptr db = open_database(path);
             folder = db->lookup_node_info(message).parent_id;
+
+            // Only assert on a subject no other message shares, otherwise a
+            // surviving copy would look like a leak.
+            size_t sharing = 0;
+            for(size_t i = 0; i < messages.size(); ++i)
+            {
+                property_bag other(db->lookup_node(messages[i]));
+                if(!other.prop_exists(PR_SUBJECT_W))
+                    continue;
+
+                const std::wstring text = other.read_prop<std::wstring>(PR_SUBJECT_W);
+                if(messages[i] == message)
+                    subject = text;
+                else if(text == subject && !text.empty())
+                    ++sharing;
+            }
+
+            unique_subject = sharing == 0 && subject.size() > 4;
         }
 
         {
@@ -840,6 +921,14 @@ void test_delete_message(const std::string& sample)
         }
 
         check_refcounts<T>(db, path);
+
+        // A table cell wider than the row points at a heap allocation holding the
+        // cached subject in clear text. Removing the row has to free it, not just
+        // orphan it, or the text stays in a block the store still reads.
+        if(unique_subject)
+            assert(count_in_live_blocks(slurp(path), encoded_needle(subject),
+                                        bbt_snapshot(db)) == 0);
+
         db.reset();
 
         walk_store(path);

--- a/test/deletetest.cpp
+++ b/test/deletetest.cpp
@@ -581,6 +581,15 @@ void test_pc_set_inline(const std::string& sample)
     std::filesystem::remove(narrow(path));
 }
 
+std::vector<pstsdk::row_id> table_rows(const pstsdk::shared_db_ptr& db, pstsdk::node_id nid);
+
+// Same as table_rows, but tolerates a table node that is not there
+std::vector<pstsdk::row_id> table_rows_or_empty(const pstsdk::shared_db_ptr& db, pstsdk::node_id nid)
+{
+    try { return table_rows(db, nid); }
+    catch(pstsdk::key_not_found<pstsdk::node_id>&) { return std::vector<pstsdk::row_id>(); }
+}
+
 std::vector<pstsdk::row_id> table_rows(const pstsdk::shared_db_ptr& db, pstsdk::node_id nid)
 {
     pstsdk::table tc(db->lookup_node(nid));
@@ -744,6 +753,176 @@ void test_tc_remove_row(const std::string& sample)
     assert(emptied > 0);
 }
 
+// Opens everything the pst layer can reach and touches enough of each item to
+// force the blocks behind it to be read and validated.
+void walk_store(const std::wstring& path)
+{
+    using namespace pstsdk;
+
+    pst store(path);
+
+    for(pst::folder_iterator i = store.folder_begin(); i != store.folder_end(); ++i)
+    {
+        // Bind the folder rather than working through the iterator: it yields by
+        // value, and const_table_row_iter::equal compares the table pointer, so
+        // begin() and end() taken off two temporaries never meet.
+        folder f = *i;
+        f.get_name();
+
+        for(folder::message_iterator m = f.message_begin(); m != f.message_end(); ++m)
+        {
+            message item = *m;
+            item.get_attachment_count();
+            item.get_recipient_count();
+
+            if(item.has_subject())
+                item.get_subject();
+        }
+    }
+}
+
+// Deletes every message in the store, one per copy, through the public entry
+// point. This is the first test that holds the whole stack to account at once:
+// the node is gone, the folder's row and count agree, the row index still lines
+// up with the matrix, no block is orphaned, and the store still reads.
+template<typename T>
+void test_delete_message(const std::string& sample)
+{
+    using namespace pstsdk;
+
+    std::vector<node_id> messages;
+    {
+        shared_db_ptr db = open_database(widen(sample));
+        std::vector<node_id> nids = all_nids(db);
+
+        for(size_t i = 0; i < nids.size(); ++i)
+            if(get_nid_type(nids[i]) == nid_type_message)
+                messages.push_back(nids[i]);
+    }
+    assert(!messages.empty());
+
+    for(size_t victim = 0; victim < messages.size(); ++victim)
+    {
+        std::wstring path = copy_sample(sample, "delmsg");
+        const node_id message = messages[victim];
+
+        node_id folder = 0;
+        {
+            shared_db_ptr db = open_database(path);
+            folder = db->lookup_node_info(message).parent_id;
+        }
+
+        {
+            std::shared_ptr<file> f(new file(path, true));
+            shared_db_ptr db = open_database(f);
+            delete_message(db, message);
+        }
+
+        shared_db_ptr db = open_database(path);
+
+        bool missing = false;
+        try { db->lookup_node_info(message); }
+        catch(key_not_found<node_id>&) { missing = true; }
+        assert(missing);
+
+        if(folder != 0)
+        {
+            const node_id contents = make_nid(nid_type_contents_table, get_nid_index(folder));
+            std::vector<row_id> rows = table_rows(db, contents);
+
+            for(size_t i = 0; i < rows.size(); ++i)
+                assert(rows[i] != message);
+
+            property_bag bag(db->lookup_node(folder));
+            assert(bag.read_prop<slong>(PR_CONTENT_COUNT) == (slong)rows.size());
+
+            check_row_index(db, contents);
+        }
+
+        check_refcounts<T>(db, path);
+        db.reset();
+
+        walk_store(path);
+        std::filesystem::remove(narrow(path));
+    }
+}
+
+// Deletes each folder below the root, one per copy. A folder takes its property
+// context, its three tables and everything underneath it, so the check is that
+// none of those node ids survive and the store still reads.
+template<typename T>
+void test_delete_folder(const std::string& sample)
+{
+    using namespace pstsdk;
+
+    std::vector<node_id> folders;
+    {
+        shared_db_ptr db = open_database(widen(sample));
+        std::vector<node_id> nids = all_nids(db);
+
+        for(size_t i = 0; i < nids.size(); ++i)
+            if(get_nid_type(nids[i]) == nid_type_folder && nids[i] != nid_root_folder)
+                folders.push_back(nids[i]);
+    }
+    assert(!folders.empty());
+
+    for(size_t victim = 0; victim < folders.size(); ++victim)
+    {
+        std::wstring path = copy_sample(sample, "delfolder");
+        const node_id target = folders[victim];
+
+        node_id parent = 0;
+        std::vector<node_id> doomed;
+        {
+            shared_db_ptr db = open_database(path);
+            parent = db->lookup_node_info(target).parent_id;
+
+            doomed.push_back(target);
+            const nid_type tables[] = { nid_type_contents_table, nid_type_hierarchy_table,
+                                        nid_type_associated_contents_table };
+
+            for(size_t i = 0; i < sizeof(tables) / sizeof(tables[0]); ++i)
+                doomed.push_back(make_nid(tables[i], get_nid_index(target)));
+
+            std::vector<row_id> messages =
+                table_rows_or_empty(db, make_nid(nid_type_contents_table, get_nid_index(target)));
+            for(size_t i = 0; i < messages.size(); ++i)
+                doomed.push_back(messages[i]);
+        }
+
+        {
+            std::shared_ptr<file> f(new file(path, true));
+            shared_db_ptr db = open_database(f);
+            delete_folder(db, target);
+        }
+
+        shared_db_ptr db = open_database(path);
+
+        for(size_t i = 0; i < doomed.size(); ++i)
+        {
+            bool missing = false;
+            try { db->lookup_node_info(doomed[i]); }
+            catch(key_not_found<node_id>&) { missing = true; }
+            assert(missing);
+        }
+
+        if(parent != 0)
+        {
+            const node_id hierarchy = make_nid(nid_type_hierarchy_table, get_nid_index(parent));
+            std::vector<row_id> rows = table_rows_or_empty(db, hierarchy);
+
+            for(size_t i = 0; i < rows.size(); ++i)
+                assert(rows[i] != target);
+        }
+
+        check_refcounts<T>(db, path);
+        db.reset();
+
+        walk_store(path);
+        std::filesystem::remove(narrow(path));
+    }
+}
+
 } // end anonymous namespace
 
 void test_delete()
@@ -779,4 +958,12 @@ void test_delete()
     test_tc_remove_row<pstsdk::ulonglong>("test_unicode.pst");
     test_tc_remove_row<pstsdk::ulong>("test_ansi.pst");
     test_tc_remove_row<pstsdk::ulonglong>("submessage.pst");
+
+    test_delete_message<pstsdk::ulonglong>("test_unicode.pst");
+    test_delete_message<pstsdk::ulong>("test_ansi.pst");
+    test_delete_message<pstsdk::ulonglong>("submessage.pst");
+
+    test_delete_folder<pstsdk::ulonglong>("test_unicode.pst");
+    test_delete_folder<pstsdk::ulong>("test_ansi.pst");
+    test_delete_folder<pstsdk::ulonglong>("submessage.pst");
 }

--- a/test/deletetest.cpp
+++ b/test/deletetest.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstdlib>
 #include <cassert>
 #include <filesystem>
 #include <fstream>
@@ -1012,6 +1013,91 @@ void test_delete_folder(const std::string& sample)
     }
 }
 
+// Every store under test/ keeps its row matrices inline, so nothing here reaches
+// the subnode path, which is the one a real folder takes past a few dozen
+// messages. Point PSTSDK_TEST_CORPUS at a directory of real stores to cover it:
+//
+//   PSTSDK_TEST_CORPUS=~/corpus ninja -C build test
+//
+// Each store is copied, then every message in it is deleted one at a time, with
+// the reference graph checked as it goes.
+template<typename T>
+void drain_store(const std::string& source)
+{
+    using namespace pstsdk;
+
+    const std::wstring path = widen(source + ".draining");
+    std::filesystem::copy_file(source, narrow(path),
+                               std::filesystem::copy_options::overwrite_existing);
+
+    size_t deleted = 0;
+
+    for(;;)
+    {
+        std::vector<node_id> left;
+        {
+            shared_db_ptr db = open_database(path);
+            std::vector<node_id> nids = all_nids(db);
+
+            for(size_t i = 0; i < nids.size(); ++i)
+                if(get_nid_type(nids[i]) == nid_type_message)
+                    left.push_back(nids[i]);
+        }
+
+        if(left.empty())
+            break;
+
+        {
+            std::shared_ptr<file> f(new file(path, true));
+            shared_db_ptr db = open_database(f);
+            delete_message(db, left[0]);
+        }
+
+        ++deleted;
+
+        if(deleted % 25 == 0 || left.size() == 1)
+        {
+            shared_db_ptr db = open_database(path);
+            check_refcounts<T>(db, path);
+            db.reset();
+            walk_store(path);
+        }
+    }
+
+    assert(deleted > 0);
+    std::wcout << L"  drained " << deleted << L" messages from "
+               << widen(source) << std::endl;
+
+    std::filesystem::remove(narrow(path));
+}
+
+void test_corpus()
+{
+    const char* corpus = getenv("PSTSDK_TEST_CORPUS");
+    if(!corpus)
+        return;
+
+    for(std::filesystem::directory_iterator i(corpus);
+        i != std::filesystem::directory_iterator(); ++i)
+    {
+        if(i->path().extension() != ".pst")
+            continue;
+
+        const std::string source = i->path().string();
+        std::vector<pstsdk::byte> head = slurp(widen(source));
+        if(head.size() < 12)
+            continue;
+
+        pstsdk::ushort version;
+        memcpy(&version, &head[10], sizeof(version));
+
+        if(version >= pstsdk::disk::database_format_unicode_min)
+            drain_store<pstsdk::ulonglong>(source);
+        else
+            drain_store<pstsdk::ulong>(source);
+    }
+}
+
 } // end anonymous namespace
 
 void test_delete()
@@ -1055,4 +1141,6 @@ void test_delete()
     test_delete_folder<pstsdk::ulonglong>("test_unicode.pst");
     test_delete_folder<pstsdk::ulong>("test_ansi.pst");
     test_delete_folder<pstsdk::ulonglong>("submessage.pst");
+
+    test_corpus();
 }

--- a/test/deletetest.cpp
+++ b/test/deletetest.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <map>
 #include <vector>
 
 #include "pstsdk/ndb.h"
@@ -338,10 +339,208 @@ void test_nbt_drain(const std::string& sample)
     std::filesystem::remove(narrow(path));
 }
 
+std::map<pstsdk::block_id, pstsdk::block_info> bbt_snapshot(const pstsdk::shared_db_ptr& db)
+{
+    std::map<pstsdk::block_id, pstsdk::block_info> blocks;
+    std::shared_ptr<pstsdk::bbt_page> root = db->read_bbt_root();
+
+    for(pstsdk::const_blockinfo_iterator i = root->begin(); i != root->end(); ++i)
+        blocks[(*i).id] = *i;
+
+    return blocks;
+}
+
+template<typename T>
+std::vector<pstsdk::byte> read_raw_block(pstsdk::file& f,
+                                         const std::map<pstsdk::block_id, pstsdk::block_info>& bbt,
+                                         pstsdk::block_id bid)
+{
+    using namespace pstsdk;
+
+    std::map<block_id, block_info>::const_iterator entry =
+        bbt.find(bid & ~block_id(disk::block_id_attached_bit));
+    assert(entry != bbt.end());
+
+    std::vector<byte> buffer(disk::align_disk<T>(entry->second.size));
+    f.read(buffer, entry->second.address);
+    buffer.resize(entry->second.size);
+    return buffer;
+}
+
+template<typename T>
+void count_subnode_tree(pstsdk::file& f, const std::map<pstsdk::block_id, pstsdk::block_info>& bbt,
+                        pstsdk::block_id bid, std::map<pstsdk::block_id, unsigned>& refs);
+
+template<typename T>
+void count_data_tree(pstsdk::file& f, const std::map<pstsdk::block_id, pstsdk::block_info>& bbt,
+                     pstsdk::block_id bid, std::map<pstsdk::block_id, unsigned>& refs)
+{
+    using namespace pstsdk;
+
+    if(bid == 0)
+        return;
+
+    ++refs[bid & ~block_id(disk::block_id_attached_bit)];
+
+    if(disk::bid_is_external(bid))
+        return;
+
+    std::vector<byte> raw = read_raw_block<T>(f, bbt, bid);
+    const disk::extended_block<T>* xblock =
+        reinterpret_cast<const disk::extended_block<T>*>(&raw[0]);
+
+    for(pstsdk::ushort i = 0; i < xblock->count; ++i)
+        count_data_tree<T>(f, bbt, xblock->bid[i], refs);
+}
+
+template<typename T>
+void count_subnode_tree(pstsdk::file& f, const std::map<pstsdk::block_id, pstsdk::block_info>& bbt,
+                        pstsdk::block_id bid, std::map<pstsdk::block_id, unsigned>& refs)
+{
+    using namespace pstsdk;
+
+    if(bid == 0)
+        return;
+
+    ++refs[bid & ~block_id(disk::block_id_attached_bit)];
+
+    std::vector<byte> raw = read_raw_block<T>(f, bbt, bid);
+    const disk::sub_block<T, disk::sub_leaf_entry<T> >* leaf =
+        reinterpret_cast<const disk::sub_block<T, disk::sub_leaf_entry<T> >*>(&raw[0]);
+
+    if(leaf->level == 0)
+    {
+        for(pstsdk::ushort i = 0; i < leaf->count; ++i)
+        {
+            count_data_tree<T>(f, bbt, leaf->entry[i].data, refs);
+            count_subnode_tree<T>(f, bbt, leaf->entry[i].sub, refs);
+        }
+
+        return;
+    }
+
+    const disk::sub_block<T, disk::sub_nonleaf_entry<T> >* nonleaf =
+        reinterpret_cast<const disk::sub_block<T, disk::sub_nonleaf_entry<T> >*>(&raw[0]);
+
+    for(pstsdk::ushort i = 0; i < nonleaf->count; ++i)
+        count_subnode_tree<T>(f, bbt, nonleaf->entry[i].sub_block_bid, refs);
+}
+
+// Rebuilds the true reference graph from the NBT down and holds the BBT to it.
+// This is the oracle that catches a delete which collected too few blocks: an
+// uncollected one is still in the tree but nothing points at it any more.
+template<typename T>
+void check_refcounts(const pstsdk::shared_db_ptr& db, const std::wstring& path)
+{
+    using namespace pstsdk;
+
+    std::map<block_id, block_info> bbt = bbt_snapshot(db);
+    std::map<block_id, unsigned> refs;
+    file f(path);
+
+    std::shared_ptr<nbt_page> root = db->read_nbt_root();
+    for(const_nodeinfo_iterator i = root->begin(); i != root->end(); ++i)
+    {
+        count_data_tree<T>(f, bbt, (*i).data_bid, refs);
+        count_subnode_tree<T>(f, bbt, (*i).sub_bid, refs);
+    }
+
+    for(std::map<block_id, block_info>::const_iterator i = bbt.begin(); i != bbt.end(); ++i)
+    {
+        const unsigned actual = refs.count(i->first) ? refs[i->first] : 0;
+        assert(actual > 0);
+        assert(i->second.ref_count == actual + disk::block_unreferenced);
+    }
+}
+
+// Deletes every node in turn, each from a fresh copy, and diffs the BBT across
+// the delete. A block that lost its last owner has to be gone from the tree and
+// zeroed on disk; a block someone else still owns has to survive intact with its
+// count down by exactly one.
+template<typename T>
+void test_delete_node(const std::string& sample)
+{
+    using namespace pstsdk;
+
+    std::vector<node_id> nids;
+    {
+        shared_db_ptr db = open_database(widen(sample));
+        nids = all_nids(db);
+    }
+
+    size_t scrubbed = 0;
+    size_t decremented = 0;
+
+    for(size_t victim = 0; victim < nids.size(); ++victim)
+    {
+        std::wstring path = copy_sample(sample, "delnode");
+
+        std::map<block_id, block_info> before;
+        {
+            shared_db_ptr db = open_database(path);
+            before = bbt_snapshot(db);
+        }
+
+        {
+            std::shared_ptr<file> f(new file(path, true));
+            std::shared_ptr<database_impl<T> > impl =
+                std::dynamic_pointer_cast<database_impl<T> >(open_database(f));
+            db_writer<T> writer(impl);
+            writer.delete_node(nids[victim]);
+            writer.commit();
+        }
+
+        shared_db_ptr db = open_database(path);
+        std::map<block_id, block_info> after = bbt_snapshot(db);
+        file raw(path);
+
+        for(std::map<block_id, block_info>::const_iterator i = before.begin(); i != before.end(); ++i)
+        {
+            std::map<block_id, block_info>::const_iterator survivor = after.find(i->first);
+
+            if(survivor == after.end())
+            {
+                std::vector<byte> extent(disk::align_disk<T>(i->second.size));
+                raw.read(extent, i->second.address);
+
+                for(size_t b = 0; b < extent.size(); ++b)
+                    assert(extent[b] == 0);
+
+                ++scrubbed;
+                continue;
+            }
+
+            assert(survivor->second.address == i->second.address);
+            assert(survivor->second.ref_count == i->second.ref_count ||
+                   survivor->second.ref_count == i->second.ref_count - 1);
+
+            if(survivor->second.ref_count < i->second.ref_count)
+                ++decremented;
+        }
+
+        assert(all_nids(db).size() == nids.size() - 1);
+        check_refcounts<T>(db, path);
+
+        db.reset();
+        std::filesystem::remove(narrow(path));
+    }
+
+    assert(scrubbed > 0);
+    // the empty-table blocks every sample store shares, losing one owner apiece
+    assert(decremented > 0);
+}
+
 } // end anonymous namespace
 
 void test_delete()
 {
+    // the invariant the delete tests lean on has to hold before they start
+    check_refcounts<pstsdk::ulonglong>(pstsdk::open_database(widen("test_unicode.pst")), widen("test_unicode.pst"));
+    check_refcounts<pstsdk::ulong>(pstsdk::open_database(widen("test_ansi.pst")), widen("test_ansi.pst"));
+    check_refcounts<pstsdk::ulonglong>(pstsdk::open_database(widen("submessage.pst")), widen("submessage.pst"));
+    check_refcounts<pstsdk::ulonglong>(pstsdk::open_database(widen("sample1.pst")), widen("sample1.pst"));
+    check_refcounts<pstsdk::ulong>(pstsdk::open_database(widen("sample2.pst")), widen("sample2.pst"));
+
     test_block_roundtrip<pstsdk::ulonglong>("test_unicode.pst");
     test_block_roundtrip<pstsdk::ulong>("test_ansi.pst");
     test_block_roundtrip<pstsdk::ulonglong>("submessage.pst");
@@ -355,4 +554,8 @@ void test_delete()
 
     test_nbt_drain<pstsdk::ulonglong>("test_unicode.pst");
     test_nbt_drain<pstsdk::ulong>("test_ansi.pst");
+
+    test_delete_node<pstsdk::ulonglong>("test_unicode.pst");
+    test_delete_node<pstsdk::ulong>("test_ansi.pst");
+    test_delete_node<pstsdk::ulonglong>("submessage.pst");
 }

--- a/test/deletetest.cpp
+++ b/test/deletetest.cpp
@@ -605,6 +605,17 @@ std::vector<pstsdk::row_id> table_rows_or_empty(const pstsdk::shared_db_ptr& db,
     catch(pstsdk::key_not_found<pstsdk::node_id>&) { return std::vector<pstsdk::row_id>(); }
 }
 
+std::vector<pstsdk::row_id> table_rows(const pstsdk::node& owner, pstsdk::node_id sub)
+{
+    pstsdk::table tc(owner.lookup(sub));
+    std::vector<pstsdk::row_id> rows;
+
+    for(size_t i = 0; i < tc.size(); ++i)
+        rows.push_back(tc[i].get_row_id());
+
+    return rows;
+}
+
 std::vector<pstsdk::row_id> table_rows(const pstsdk::shared_db_ptr& db, pstsdk::node_id nid)
 {
     pstsdk::table tc(db->lookup_node(nid));
@@ -1013,6 +1024,94 @@ void test_delete_folder(const std::string& sample)
     }
 }
 
+// Deletes every attachment of every message that has one, from a fresh copy each
+// time. The message has to survive with one fewer attachment and the rest intact,
+// and the attachment's own subnode has to be gone rather than orphaned.
+template<typename T>
+void test_delete_attachment(const std::string& sample)
+{
+    using namespace pstsdk;
+
+    std::vector<std::pair<node_id, std::vector<row_id> > > owners;
+    {
+        shared_db_ptr db = open_database(widen(sample));
+        std::vector<node_id> nids = all_nids(db);
+
+        for(size_t i = 0; i < nids.size(); ++i)
+        {
+            if(get_nid_type(nids[i]) != nid_type_message)
+                continue;
+
+            std::vector<row_id> rows;
+            try { rows = table_rows(db->lookup_node(nids[i]), nid_attachment_table); }
+            catch(key_not_found<node_id>&) { continue; }
+
+            if(!rows.empty())
+                owners.push_back(std::make_pair(nids[i], rows));
+        }
+    }
+    assert(!owners.empty());
+
+    size_t cleared = 0;
+
+    for(size_t m = 0; m < owners.size(); ++m)
+    {
+        const std::vector<row_id>& all = owners[m].second;
+
+        for(size_t victim = 0; victim < all.size(); ++victim)
+        {
+            std::wstring path = copy_sample(sample, "delatt");
+
+            {
+                std::shared_ptr<file> f(new file(path, true));
+                shared_db_ptr db = open_database(f);
+                delete_attachment(db, owners[m].first, (node_id)all[victim]);
+            }
+
+            shared_db_ptr db = open_database(path);
+            node owner = db->lookup_node(owners[m].first);
+            std::vector<row_id> left = table_rows(owner, nid_attachment_table);
+            assert(left.size() == all.size() - 1);
+
+            for(size_t i = 0; i < left.size(); ++i)
+            {
+                assert(left[i] != all[victim]);
+                // the survivors still resolve to real subnodes
+                owner.lookup((node_id)left[i]);
+            }
+
+            bool gone = false;
+            try { owner.lookup((node_id)all[victim]); }
+            catch(key_not_found<node_id>&) { gone = true; }
+            assert(gone);
+
+            message item(db->lookup_node(owners[m].first));
+            assert(item.get_attachment_count() == left.size());
+
+            // These stores do not record PR_HASATTACH anywhere, in the message
+            // or in the folder's cached row, so a client derives it from the
+            // attachment table. Checked when present, not required to be.
+            if(left.empty())
+            {
+                property_bag bag(db->lookup_node(owners[m].first));
+                if(bag.prop_exists(PR_HASATTACH))
+                {
+                    assert(!bag.read_prop<slong>(PR_HASATTACH));
+                    ++cleared;
+                }
+            }
+
+            check_refcounts<T>(db, path);
+            db.reset();
+
+            walk_store(path);
+            std::filesystem::remove(narrow(path));
+        }
+    }
+
+    (void)cleared;
+}
+
 // Every store under test/ keeps its row matrices inline, so nothing here reaches
 // the subnode path, which is the one a real folder takes past a few dozen
 // messages. Point PSTSDK_TEST_CORPUS at a directory of real stores to cover it:
@@ -1071,6 +1170,89 @@ void drain_store(const std::string& source)
     std::filesystem::remove(narrow(path));
 }
 
+// Strips every attachment from every message, then confirms the messages are all
+// still there and readable. Real stores carry the attachment shapes the samples
+// do not: many per message, embedded messages, and blocks big enough to need an
+// extended data tree.
+template<typename T>
+void strip_attachments(const std::string& source)
+{
+    using namespace pstsdk;
+
+    const std::wstring path = widen(source + ".stripping");
+    std::filesystem::copy_file(source, narrow(path),
+                               std::filesystem::copy_options::overwrite_existing);
+
+    size_t removed = 0;
+    size_t messages = 0;
+
+    for(;;)
+    {
+        node_id owner = 0;
+        row_id victim = 0;
+        {
+            shared_db_ptr db = open_database(path);
+            std::vector<node_id> nids = all_nids(db);
+
+            for(size_t i = 0; i < nids.size() && owner == 0; ++i)
+            {
+                if(get_nid_type(nids[i]) != nid_type_message)
+                    continue;
+
+                std::vector<row_id> rows;
+                try { rows = table_rows(db->lookup_node(nids[i]), nid_attachment_table); }
+                catch(key_not_found<node_id>&) { continue; }
+
+                if(rows.empty())
+                    continue;
+
+                owner = nids[i];
+                victim = rows[0];
+            }
+
+            if(owner == 0)
+            {
+                messages = 0;
+                std::shared_ptr<nbt_page> root = db->read_nbt_root();
+                for(const_nodeinfo_iterator i = root->begin(); i != root->end(); ++i)
+                    if(get_nid_type((*i).id) == nid_type_message)
+                        ++messages;
+            }
+        }
+
+        if(owner == 0)
+            break;
+
+        {
+            std::shared_ptr<file> f(new file(path, true));
+            shared_db_ptr db = open_database(f);
+            delete_attachment(db, owner, (node_id)victim);
+        }
+
+        ++removed;
+
+        if(removed % 25 == 0)
+        {
+            shared_db_ptr db = open_database(path);
+            check_refcounts<T>(db, path);
+            db.reset();
+            walk_store(path);
+        }
+    }
+
+    {
+        shared_db_ptr db = open_database(path);
+        check_refcounts<T>(db, path);
+        db.reset();
+        walk_store(path);
+    }
+
+    std::wcout << L"  stripped " << removed << L" attachments from "
+               << widen(source) << L", " << messages << L" messages intact" << std::endl;
+
+    std::filesystem::remove(narrow(path));
+}
+
 void test_corpus()
 {
     const char* corpus = getenv("PSTSDK_TEST_CORPUS");
@@ -1092,9 +1274,15 @@ void test_corpus()
         memcpy(&version, &head[10], sizeof(version));
 
         if(version >= pstsdk::disk::database_format_unicode_min)
+        {
+            strip_attachments<pstsdk::ulonglong>(source);
             drain_store<pstsdk::ulonglong>(source);
+        }
         else
+        {
+            strip_attachments<pstsdk::ulong>(source);
             drain_store<pstsdk::ulong>(source);
+        }
     }
 }
 
@@ -1141,6 +1329,8 @@ void test_delete()
     test_delete_folder<pstsdk::ulonglong>("test_unicode.pst");
     test_delete_folder<pstsdk::ulong>("test_ansi.pst");
     test_delete_folder<pstsdk::ulonglong>("submessage.pst");
+
+    test_delete_attachment<pstsdk::ulonglong>("submessage.pst");
 
     test_corpus();
 }

--- a/test/deletetest.cpp
+++ b/test/deletetest.cpp
@@ -1,0 +1,358 @@
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <vector>
+
+#include "pstsdk/ndb.h"
+#include "pstsdk/pst.h"
+
+#include "test.h"
+
+namespace
+{
+
+std::wstring widen(const std::string& s) { return std::wstring(s.begin(), s.end()); }
+std::string narrow(const std::wstring& s) { return std::string(s.begin(), s.end()); }
+
+// Everything here runs against a copy. The delete design assumes the caller made
+// one, and it keeps the sample stores pristine when a test trips an assert.
+std::wstring copy_sample(const std::string& sample, const std::string& tag)
+{
+    std::string copy = tag + "-" + sample;
+    std::filesystem::copy_file(sample, copy, std::filesystem::copy_options::overwrite_existing);
+    return widen(copy);
+}
+
+std::vector<pstsdk::byte> slurp(const std::wstring& path)
+{
+    std::ifstream in(narrow(path), std::ios::binary);
+    return std::vector<pstsdk::byte>(std::istreambuf_iterator<char>(in),
+                                     std::istreambuf_iterator<char>());
+}
+
+std::vector<pstsdk::block_id> all_bids(const pstsdk::shared_db_ptr& db)
+{
+    std::vector<pstsdk::block_id> bids;
+    std::shared_ptr<pstsdk::bbt_page> root = db->read_bbt_root();
+
+    for(pstsdk::const_blockinfo_iterator i = root->begin(); i != root->end(); ++i)
+        bids.push_back((*i).id);
+
+    return bids;
+}
+
+// Rewriting every block with the bytes it already holds has to be a no-op outside
+// the header. Failing this means trailer placement, encode direction, the CRC
+// domain or the ANSI/Unicode trailer field order is wrong, and it says so before
+// there is any delete logic to blame it on.
+template<typename T>
+void test_block_roundtrip(const std::string& sample)
+{
+    using namespace pstsdk;
+
+    std::wstring path = copy_sample(sample, "roundtrip");
+    std::vector<byte> before = slurp(path);
+    size_t shared = 0;
+
+    {
+        std::shared_ptr<file> f(new file(path, true));
+        shared_db_ptr db = open_database(f);
+        std::shared_ptr<database_impl<T> > impl = std::dynamic_pointer_cast<database_impl<T> >(db);
+        assert(impl);
+
+        db_writer<T> writer(impl);
+        std::vector<block_id> bids = all_bids(db);
+        assert(!bids.empty());
+
+        for(size_t i = 0; i < bids.size(); ++i)
+        {
+            std::vector<byte> payload = writer.read_block(bids[i]);
+
+            if(db->lookup_block_info(bids[i]).ref_count > disk::block_unreferenced + 1)
+            {
+                bool refused = false;
+                try { writer.write_block(bids[i], payload); }
+                catch(shared_block&) { refused = true; }
+                assert(refused);
+                ++shared;
+                continue;
+            }
+
+            writer.write_block(bids[i], payload);
+        }
+
+        writer.commit();
+    }
+
+    // every sample store shares the blocks behind its empty tables, so the refusal
+    // above is exercised rather than merely present
+    assert(shared > 0);
+
+    std::vector<byte> after = slurp(path);
+    assert(after.size() == before.size());
+
+    for(size_t i = sizeof(disk::header<T>); i < after.size(); ++i)
+        assert(after[i] == before[i]);
+
+    const disk::header<T>* was = reinterpret_cast<const disk::header<T>*>(&before[0]);
+    const disk::header<T>* is = reinterpret_cast<const disk::header<T>*>(&after[0]);
+    assert(is->dwUnique == was->dwUnique + 1);
+    assert(is->root_info.fAMapValid == disk::invalid_amap);
+    assert(is->root_info.ibFileEof == was->root_info.ibFileEof);
+
+    // and the store still opens under PSTSDK_VALIDATION_LEVEL_FULL, which checks
+    // every page CRC, block CRC and signature on the way through
+    {
+        shared_db_ptr db = open_database(path);
+        assert(std::dynamic_pointer_cast<database_impl<T> >(db));
+    }
+
+    std::filesystem::remove(narrow(path));
+}
+
+// Shrinking is the only resize primitive B allows, and the interesting case is a
+// shrink that crosses a 64 byte slot boundary, because that moves the trailer and
+// leaves the old one behind unless the whole extent is cleared first.
+template<typename T>
+void test_block_shrink(const std::string& sample)
+{
+    using namespace pstsdk;
+
+    std::wstring path = copy_sample(sample, "shrink");
+    size_t shrunk = 0;
+
+    {
+        std::shared_ptr<file> f(new file(path, true));
+        shared_db_ptr db = open_database(f);
+        std::shared_ptr<database_impl<T> > impl = std::dynamic_pointer_cast<database_impl<T> >(db);
+        db_writer<T> writer(impl);
+
+        std::vector<block_id> bids = all_bids(db);
+        for(size_t i = 0; i < bids.size(); ++i)
+        {
+            block_info bi = db->lookup_block_info(bids[i]);
+            if(bi.ref_count > disk::block_unreferenced + 1 || bi.size <= 64)
+                continue;
+
+            // enough to guarantee at least one slot is given back
+            const size_t target = bi.size - 64;
+            const ulonglong old_trailer =
+                bi.address + disk::align_disk<T>(bi.size) - sizeof(disk::block_trailer<T>);
+
+            std::vector<byte> payload = writer.read_block(bids[i]);
+            payload.resize(target);
+            writer.write_block(bids[i], payload);
+
+            assert(db->lookup_block_info(bids[i]).size == target);
+            assert(writer.read_block(bids[i]) == payload);
+
+            // the trailer moved, so nothing may be left where it used to sit
+            const ulonglong new_end = bi.address + disk::align_disk<T>(target);
+            if(old_trailer >= new_end)
+            {
+                std::vector<byte> stale(sizeof(disk::block_trailer<T>));
+                file check(path);
+                check.read(stale, old_trailer);
+                for(size_t b = 0; b < stale.size(); ++b)
+                    assert(stale[b] == 0);
+            }
+
+            ++shrunk;
+        }
+
+        // growth has nowhere to go, so it must be refused outright
+        block_info bi = db->lookup_block_info(bids[0]);
+        bool refused = false;
+        try { writer.write_block(bids[0], std::vector<byte>(bi.size + 1, 0)); }
+        catch(can_not_resize&) { refused = true; }
+        assert(refused);
+
+        writer.commit();
+    }
+
+    assert(shrunk > 0);
+    std::filesystem::remove(narrow(path));
+}
+
+std::vector<pstsdk::node_id> all_nids(const pstsdk::shared_db_ptr& db)
+{
+    std::vector<pstsdk::node_id> nids;
+    std::shared_ptr<pstsdk::nbt_page> root = db->read_nbt_root();
+
+    for(pstsdk::const_nodeinfo_iterator i = root->begin(); i != root->end(); ++i)
+        nids.push_back((*i).id);
+
+    return nids;
+}
+
+// Reads the BTree straight off disk rather than through the SDK, so it can assert
+// the structural invariants the SDK's own readers quietly depend on. Returns the
+// page's first key and appends every leaf key it passes, left to right.
+template<typename T>
+T check_bt_page(pstsdk::file& f, pstsdk::ulonglong address, std::vector<T>& keys)
+{
+    using namespace pstsdk;
+
+    const size_t meta = disk::page<T>::page_data_size - sizeof(T);
+    std::vector<byte> p(disk::page_size);
+    f.read(p, address);
+
+    const uint count = p[meta];
+    const uint entry_size = p[meta + 2];
+    const uint level = p[meta + 3];
+
+    assert(count > 0);
+
+    T previous = 0;
+    for(uint i = 0; i < count; ++i)
+    {
+        T key;
+        memcpy(&key, &p[i * entry_size], sizeof(T));
+        assert(i == 0 || previous < key);
+        previous = key;
+
+        if(level == 0)
+        {
+            keys.push_back(key);
+            continue;
+        }
+
+        T child;
+        memcpy(&child, &p[i * entry_size + 2 * sizeof(T)], sizeof(T));
+        assert(check_bt_page<T>(f, child, keys) == key);
+    }
+
+    T first;
+    memcpy(&first, &p[0], sizeof(T));
+    return first;
+}
+
+// Drops one node id at a time, each from a fresh copy, and checks that what is
+// left is still a well formed tree. Deleting a node without also unlinking what
+// points at it leaves the store semantically inconsistent, which is fine: this
+// exercises primitive A on its own.
+template<typename T>
+void test_nbt_remove(const std::string& sample)
+{
+    using namespace pstsdk;
+
+    std::vector<node_id> original;
+    {
+        shared_db_ptr db = open_database(widen(sample));
+        original = all_nids(db);
+    }
+    assert(original.size() > 1);
+
+    for(size_t victim = 0; victim < original.size(); ++victim)
+    {
+        std::wstring path = copy_sample(sample, "nbtremove");
+
+        {
+            std::shared_ptr<file> f(new file(path, true));
+            std::shared_ptr<database_impl<T> > impl =
+                std::dynamic_pointer_cast<database_impl<T> >(open_database(f));
+            db_writer<T> writer(impl);
+            writer.nbt_remove(original[victim]);
+            writer.commit();
+        }
+
+        std::vector<byte> raw = slurp(path);
+        const disk::header<T>* h = reinterpret_cast<const disk::header<T>*>(&raw[0]);
+
+        std::vector<T> keys;
+        {
+            file f(path);
+            check_bt_page<T>(f, h->root_info.brefNBT.ib, keys);
+        }
+        assert(keys.size() == original.size() - 1);
+
+        // and the SDK's own iterators agree, which is what catches an empty page:
+        // end() is built from root->last(), so one poisons the whole range
+        shared_db_ptr db = open_database(path);
+        std::vector<node_id> remaining = all_nids(db);
+        assert(remaining.size() == original.size() - 1);
+
+        for(size_t i = 0; i < remaining.size(); ++i)
+            assert(remaining[i] != original[victim]);
+
+        bool missing = false;
+        try { db->lookup_node_info(original[victim]); }
+        catch(key_not_found<node_id>&) { missing = true; }
+        assert(missing);
+
+        db.reset();
+        std::filesystem::remove(narrow(path));
+    }
+}
+
+// Removing one entry never empties a page in stores this small, so the recursive
+// pruning path only shows up if the tree is drained. Takes every node but the last
+// from a single copy, revalidating the whole tree after each one.
+template<typename T>
+void test_nbt_drain(const std::string& sample)
+{
+    using namespace pstsdk;
+
+    std::wstring path = copy_sample(sample, "nbtdrain");
+    std::vector<node_id> nids;
+    ulonglong root;
+
+    {
+        std::vector<byte> raw = slurp(path);
+        root = reinterpret_cast<const disk::header<T>*>(&raw[0])->root_info.brefNBT.ib;
+        shared_db_ptr db = open_database(path);
+        nids = all_nids(db);
+    }
+    assert(nids.size() > 2);
+
+    std::shared_ptr<file> f(new file(path, true));
+    std::shared_ptr<database_impl<T> > impl =
+        std::dynamic_pointer_cast<database_impl<T> >(open_database(f));
+    db_writer<T> writer(impl);
+
+    for(size_t i = 0; i + 1 < nids.size(); ++i)
+    {
+        writer.nbt_remove(nids[i]);
+        writer.commit();
+
+        file check(path);
+        std::vector<T> keys;
+        check_bt_page<T>(check, root, keys);
+        assert(keys.size() == nids.size() - i - 1);
+    }
+
+    // one entry left, and taking it would leave no tree to point at
+    bool refused = false;
+    try { writer.nbt_remove(nids.back()); }
+    catch(database_corrupt&) { refused = true; }
+    assert(refused);
+
+    // the refusal has to be clean: the tree is still exactly as it was
+    file check(path);
+    std::vector<T> keys;
+    check_bt_page<T>(check, root, keys);
+    assert(keys.size() == 1);
+
+    std::filesystem::remove(narrow(path));
+}
+
+} // end anonymous namespace
+
+void test_delete()
+{
+    test_block_roundtrip<pstsdk::ulonglong>("test_unicode.pst");
+    test_block_roundtrip<pstsdk::ulong>("test_ansi.pst");
+    test_block_roundtrip<pstsdk::ulonglong>("submessage.pst");
+    test_block_roundtrip<pstsdk::ulong>("sample2.pst");
+
+    test_block_shrink<pstsdk::ulonglong>("test_unicode.pst");
+    test_block_shrink<pstsdk::ulong>("test_ansi.pst");
+
+    test_nbt_remove<pstsdk::ulonglong>("test_unicode.pst");
+    test_nbt_remove<pstsdk::ulong>("test_ansi.pst");
+
+    test_nbt_drain<pstsdk::ulonglong>("test_unicode.pst");
+    test_nbt_drain<pstsdk::ulong>("test_ansi.pst");
+}

--- a/test/deletetest.cpp
+++ b/test/deletetest.cpp
@@ -1,11 +1,14 @@
+#include <algorithm>
 #include <cassert>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <iterator>
 #include <map>
+#include <utility>
 #include <vector>
 
+#include "pstsdk/ltp.h"
 #include "pstsdk/ndb.h"
 #include "pstsdk/pst.h"
 
@@ -530,6 +533,217 @@ void test_delete_node(const std::string& sample)
     assert(decremented > 0);
 }
 
+// Folder counts are PT_I4, which a property context carries inside the entry
+// rather than behind it, so updating one after a delete is a same size poke.
+template<typename T>
+void test_pc_set_inline(const std::string& sample)
+{
+    using namespace pstsdk;
+
+    std::wstring path = copy_sample(sample, "pcinline");
+    node_id folder = 0;
+
+    {
+        shared_db_ptr db = open_database(path);
+        std::vector<node_id> nids = all_nids(db);
+
+        for(size_t i = 0; i < nids.size() && folder == 0; ++i)
+            if(get_nid_type(nids[i]) == nid_type_folder)
+                folder = nids[i];
+    }
+    assert(folder != 0);
+
+    {
+        std::shared_ptr<file> f(new file(path, true));
+        std::shared_ptr<database_impl<T> > impl =
+            std::dynamic_pointer_cast<database_impl<T> >(open_database(f));
+        db_writer<T> writer(impl);
+
+        pc_set_inline(writer, folder, (prop_id)PR_CONTENT_COUNT, 4242);
+
+        bool missing = false;
+        try { pc_set_inline(writer, folder, (prop_id)0x7ffe, 1); }
+        catch(key_not_found<prop_id>&) { missing = true; }
+        assert(missing);
+
+        writer.commit();
+    }
+
+    shared_db_ptr db = open_database(path);
+    property_bag bag(db->lookup_node(folder));
+    assert(bag.read_prop<slong>(PR_CONTENT_COUNT) == 4242);
+
+    // the poke must not have disturbed anything else in the heap
+    assert(bag.read_prop<slong>(PR_CONTENT_UNREAD) >= 0);
+    check_refcounts<T>(db, path);
+
+    db.reset();
+    std::filesystem::remove(narrow(path));
+}
+
+std::vector<pstsdk::row_id> table_rows(const pstsdk::shared_db_ptr& db, pstsdk::node_id nid)
+{
+    pstsdk::table tc(db->lookup_node(nid));
+    std::vector<pstsdk::row_id> rows;
+
+    for(size_t i = 0; i < tc.size(); ++i)
+        rows.push_back(tc[i].get_row_id());
+
+    return rows;
+}
+
+// Reads a table's row index straight out of the heap and holds it against the row
+// matrix. The SDK never calls lookup_row, so enumerating rows proves nothing about
+// the index, which is the half Outlook actually uses to find a message.
+void check_row_index(const pstsdk::shared_db_ptr& db, pstsdk::node_id nid)
+{
+    using namespace pstsdk;
+
+    node n = db->lookup_node(nid);
+    std::vector<byte> page(n.get_page_size(0));
+    n.read(page, 0, 0);
+
+    const disk::heap_first_header* heap =
+        reinterpret_cast<const disk::heap_first_header*>(&page[0]);
+    const disk::heap_page_map* map =
+        reinterpret_cast<const disk::heap_page_map*>(&page[heap->page_map_offset]);
+
+    // heap ids number allocations from one, and only page zero is in play here
+    const disk::tc_header* tc = reinterpret_cast<const disk::tc_header*>(
+        &page[map->allocs[get_heap_index(heap->root_id)]]);
+
+    const size_t cb_per_row = tc->size_offsets[disk::tc_offsets_bitmap];
+    const disk::bth_header* bth = reinterpret_cast<const disk::bth_header*>(
+        &page[map->allocs[get_heap_index(tc->row_btree_id)]]);
+
+    size_t rows = 0;
+    const byte* matrix = 0;
+    if(tc->row_matrix_id != 0)
+    {
+        assert(!is_subnode_id(tc->row_matrix_id));
+        const uint index = get_heap_index(tc->row_matrix_id);
+        matrix = &page[map->allocs[index]];
+        rows = (map->allocs[index + 1] - map->allocs[index]) / cb_per_row;
+    }
+
+    if(bth->root == 0)
+    {
+        assert(rows == 0);
+        return;
+    }
+
+    // the sample stores are all single level; anything deeper needs a walk
+    assert(bth->num_levels == 0);
+
+    const uint leaf = get_heap_index(bth->root);
+    const size_t stride = bth->key_size + bth->entry_size;
+    const byte* entries = &page[map->allocs[leaf]];
+    const size_t count = (map->allocs[leaf + 1] - map->allocs[leaf]) / stride;
+
+    assert(count == rows);
+
+    std::vector<size_t> seen;
+    pstsdk::ulong previous = 0;
+
+    for(size_t i = 0; i < count; ++i)
+    {
+        pstsdk::ulong key = 0;
+        size_t position = 0;
+        memcpy(&key, entries + i * stride, bth->key_size);
+        memcpy(&position, entries + i * stride + bth->key_size, bth->entry_size);
+
+        assert(i == 0 || previous < key);
+        previous = key;
+
+        assert(position < rows);
+        pstsdk::ulong at_position = 0;
+        memcpy(&at_position, matrix + position * cb_per_row, sizeof(pstsdk::ulong));
+        assert(at_position == key);
+
+        seen.push_back(position);
+    }
+
+    // every row is indexed exactly once
+    std::sort(seen.begin(), seen.end());
+    for(size_t i = 0; i < seen.size(); ++i)
+        assert(seen[i] == i);
+}
+
+// Takes every row out of every populated table, one per copy, and checks that the
+// survivors are exactly the rows that were there before minus the one removed.
+// The row moved by swap-with-last is the interesting survivor: its index changed,
+// so the row index has to have been retargeted.
+template<typename T>
+void test_tc_remove_row(const std::string& sample)
+{
+    using namespace pstsdk;
+
+    std::vector<std::pair<node_id, std::vector<row_id> > > tables;
+    {
+        shared_db_ptr db = open_database(widen(sample));
+        std::vector<node_id> nids = all_nids(db);
+
+        for(size_t i = 0; i < nids.size(); ++i)
+        {
+            const nid_type type = get_nid_type(nids[i]);
+            if(type != nid_type_contents_table && type != nid_type_hierarchy_table &&
+               type != nid_type_associated_contents_table)
+                continue;
+
+            std::vector<row_id> rows = table_rows(db, nids[i]);
+            if(!rows.empty())
+                tables.push_back(std::make_pair(nids[i], rows));
+        }
+    }
+    assert(!tables.empty());
+
+    size_t emptied = 0;
+
+    for(size_t t = 0; t < tables.size(); ++t)
+    {
+        const std::vector<row_id>& original = tables[t].second;
+
+        for(size_t victim = 0; victim < original.size(); ++victim)
+        {
+            std::wstring path = copy_sample(sample, "tcrow");
+
+            {
+                std::shared_ptr<file> f(new file(path, true));
+                std::shared_ptr<database_impl<T> > impl =
+                    std::dynamic_pointer_cast<database_impl<T> >(open_database(f));
+                db_writer<T> writer(impl);
+                tc_remove_row(writer, tables[t].first, original[victim]);
+                writer.commit();
+            }
+
+            shared_db_ptr db = open_database(path);
+            std::vector<row_id> remaining = table_rows(db, tables[t].first);
+            assert(remaining.size() == original.size() - 1);
+
+            std::vector<row_id> expected;
+            for(size_t i = 0; i < original.size(); ++i)
+                if(i != victim)
+                    expected.push_back(original[i]);
+
+            std::sort(expected.begin(), expected.end());
+            std::sort(remaining.begin(), remaining.end());
+            assert(expected == remaining);
+
+            if(remaining.empty())
+                ++emptied;
+
+            check_refcounts<T>(db, path);
+            check_row_index(db, tables[t].first);
+
+            db.reset();
+            std::filesystem::remove(narrow(path));
+        }
+    }
+
+    // the one-row tables in these stores make the drop-to-empty path real
+    assert(emptied > 0);
+}
+
 } // end anonymous namespace
 
 void test_delete()
@@ -558,4 +772,11 @@ void test_delete()
     test_delete_node<pstsdk::ulonglong>("test_unicode.pst");
     test_delete_node<pstsdk::ulong>("test_ansi.pst");
     test_delete_node<pstsdk::ulonglong>("submessage.pst");
+
+    test_pc_set_inline<pstsdk::ulonglong>("test_unicode.pst");
+    test_pc_set_inline<pstsdk::ulong>("test_ansi.pst");
+
+    test_tc_remove_row<pstsdk::ulonglong>("test_unicode.pst");
+    test_tc_remove_row<pstsdk::ulong>("test_ansi.pst");
+    test_tc_remove_row<pstsdk::ulonglong>("submessage.pst");
 }

--- a/test/deletetest.cpp
+++ b/test/deletetest.cpp
@@ -1372,6 +1372,9 @@ void check_pristine(const std::string& sample)
 
 void test_delete()
 {
+    using std::cout;
+    using std::endl;
+
     // the invariant the delete tests lean on has to hold before they start
     check_pristine<pstsdk::ulonglong>("test_unicode.pst");
     check_pristine<pstsdk::ulong>("test_ansi.pst");
@@ -1379,43 +1382,55 @@ void test_delete()
     check_pristine<pstsdk::ulonglong>("sample1.pst");
     check_pristine<pstsdk::ulong>("sample2.pst");
 
+    cout << "  test_block_roundtrip" << endl;
     test_block_roundtrip<pstsdk::ulonglong>("test_unicode.pst");
     test_block_roundtrip<pstsdk::ulong>("test_ansi.pst");
     test_block_roundtrip<pstsdk::ulonglong>("submessage.pst");
     test_block_roundtrip<pstsdk::ulong>("sample2.pst");
 
+    cout << "  test_block_shrink" << endl;
     test_block_shrink<pstsdk::ulonglong>("test_unicode.pst");
     test_block_shrink<pstsdk::ulong>("test_ansi.pst");
 
+    cout << "  test_nbt_remove" << endl;
     test_nbt_remove<pstsdk::ulonglong>("test_unicode.pst");
     test_nbt_remove<pstsdk::ulong>("test_ansi.pst");
 
+    cout << "  test_nbt_drain" << endl;
     test_nbt_drain<pstsdk::ulonglong>("test_unicode.pst");
     test_nbt_drain<pstsdk::ulong>("test_ansi.pst");
 
+    cout << "  test_delete_node" << endl;
     test_delete_node<pstsdk::ulonglong>("test_unicode.pst");
     test_delete_node<pstsdk::ulong>("test_ansi.pst");
     test_delete_node<pstsdk::ulonglong>("submessage.pst");
 
+    cout << "  test_pc_set_inline" << endl;
     test_pc_set_inline<pstsdk::ulonglong>("test_unicode.pst");
     test_pc_set_inline<pstsdk::ulong>("test_ansi.pst");
 
+    cout << "  test_tc_remove_row" << endl;
     test_tc_remove_row<pstsdk::ulonglong>("test_unicode.pst");
     test_tc_remove_row<pstsdk::ulong>("test_ansi.pst");
     test_tc_remove_row<pstsdk::ulonglong>("submessage.pst");
 
+    cout << "  test_delete_message" << endl;
     test_delete_message<pstsdk::ulonglong>("test_unicode.pst");
     test_delete_message<pstsdk::ulong>("test_ansi.pst");
     test_delete_message<pstsdk::ulonglong>("submessage.pst");
 
+    cout << "  test_delete_folder" << endl;
     test_delete_folder<pstsdk::ulonglong>("test_unicode.pst");
     test_delete_folder<pstsdk::ulong>("test_ansi.pst");
     test_delete_folder<pstsdk::ulonglong>("submessage.pst");
 
+    cout << "  test_delete_attachment" << endl;
     test_delete_attachment<pstsdk::ulonglong>("submessage.pst");
 
+    cout << "  test_wipe_free_space" << endl;
     test_wipe_free_space<pstsdk::ulonglong>(
         "submessage.pst", L"This is a message which has an embedded message attached");
 
+    cout << "  test_corpus" << endl;
     test_corpus();
 }

--- a/test/deletetest.cpp
+++ b/test/deletetest.cpp
@@ -118,7 +118,7 @@ void test_block_roundtrip(const std::string& sample)
     std::filesystem::remove(narrow(path));
 }
 
-// Shrinking is the only resize primitive B allows, and the interesting case is a
+// Shrinking is the only resize write_block allows, and the interesting case is a
 // shrink that crosses a 64 byte slot boundary, because that moves the trailer and
 // leaves the old one behind unless the whole extent is cleared first.
 template<typename T>
@@ -168,7 +168,6 @@ void test_block_shrink(const std::string& sample)
             ++shrunk;
         }
 
-        // growth has nowhere to go, so it must be refused outright
         block_info bi = db->lookup_block_info(bids[0]);
         bool refused = false;
         try { writer.write_block(bids[0], std::vector<byte>(bi.size + 1, 0)); }
@@ -238,7 +237,7 @@ T check_bt_page(pstsdk::file& f, pstsdk::ulonglong address, std::vector<T>& keys
 // Drops one node id at a time, each from a fresh copy, and checks that what is
 // left is still a well formed tree. Deleting a node without also unlinking what
 // points at it leaves the store semantically inconsistent, which is fine: this
-// exercises primitive A on its own.
+// exercises nbt_remove on its own.
 template<typename T>
 void test_nbt_remove(const std::string& sample)
 {
@@ -596,15 +595,6 @@ void test_pc_set_inline(const std::string& sample)
     std::filesystem::remove(narrow(path));
 }
 
-std::vector<pstsdk::row_id> table_rows(const pstsdk::shared_db_ptr& db, pstsdk::node_id nid);
-
-// Same as table_rows, but tolerates a table node that is not there
-std::vector<pstsdk::row_id> table_rows_or_empty(const pstsdk::shared_db_ptr& db, pstsdk::node_id nid)
-{
-    try { return table_rows(db, nid); }
-    catch(pstsdk::key_not_found<pstsdk::node_id>&) { return std::vector<pstsdk::row_id>(); }
-}
-
 std::vector<pstsdk::row_id> table_rows(const pstsdk::node& owner, pstsdk::node_id sub)
 {
     pstsdk::table tc(owner.lookup(sub));
@@ -625,6 +615,12 @@ std::vector<pstsdk::row_id> table_rows(const pstsdk::shared_db_ptr& db, pstsdk::
         rows.push_back(tc[i].get_row_id());
 
     return rows;
+}
+
+std::vector<pstsdk::row_id> table_rows_or_empty(const pstsdk::shared_db_ptr& db, pstsdk::node_id nid)
+{
+    try { return table_rows(db, nid); }
+    catch(pstsdk::key_not_found<pstsdk::node_id>&) { return std::vector<pstsdk::row_id>(); }
 }
 
 // Reads a table's row index straight out of the heap and holds it against the row
@@ -1068,7 +1064,6 @@ void test_delete_attachment(const std::string& sample)
     }
     assert(!owners.empty());
 
-    size_t cleared = 0;
 
     for(size_t m = 0; m < owners.size(); ++m)
     {
@@ -1106,15 +1101,12 @@ void test_delete_attachment(const std::string& sample)
 
             // These stores do not record PR_HASATTACH anywhere, in the message
             // or in the folder's cached row, so a client derives it from the
-            // attachment table. Checked when present, not required to be.
+            // attachment table.
             if(left.empty())
             {
                 property_bag bag(db->lookup_node(owners[m].first));
                 if(bag.prop_exists(PR_HASATTACH))
-                {
                     assert(!bag.read_prop<slong>(PR_HASATTACH));
-                    ++cleared;
-                }
             }
 
             check_refcounts<T>(db, path);
@@ -1125,7 +1117,6 @@ void test_delete_attachment(const std::string& sample)
         }
     }
 
-    (void)cleared;
 }
 
 // The one test that speaks to the point of the feature: after deleting an item
@@ -1371,16 +1362,22 @@ void test_corpus()
     }
 }
 
+template<typename T>
+void check_pristine(const std::string& sample)
+{
+    check_refcounts<T>(pstsdk::open_database(widen(sample)), widen(sample));
+}
+
 } // end anonymous namespace
 
 void test_delete()
 {
     // the invariant the delete tests lean on has to hold before they start
-    check_refcounts<pstsdk::ulonglong>(pstsdk::open_database(widen("test_unicode.pst")), widen("test_unicode.pst"));
-    check_refcounts<pstsdk::ulong>(pstsdk::open_database(widen("test_ansi.pst")), widen("test_ansi.pst"));
-    check_refcounts<pstsdk::ulonglong>(pstsdk::open_database(widen("submessage.pst")), widen("submessage.pst"));
-    check_refcounts<pstsdk::ulonglong>(pstsdk::open_database(widen("sample1.pst")), widen("sample1.pst"));
-    check_refcounts<pstsdk::ulong>(pstsdk::open_database(widen("sample2.pst")), widen("sample2.pst"));
+    check_pristine<pstsdk::ulonglong>("test_unicode.pst");
+    check_pristine<pstsdk::ulong>("test_ansi.pst");
+    check_pristine<pstsdk::ulonglong>("submessage.pst");
+    check_pristine<pstsdk::ulonglong>("sample1.pst");
+    check_pristine<pstsdk::ulong>("sample2.pst");
 
     test_block_roundtrip<pstsdk::ulonglong>("test_unicode.pst");
     test_block_roundtrip<pstsdk::ulong>("test_ansi.pst");

--- a/test/deletetest.cpp
+++ b/test/deletetest.cpp
@@ -825,6 +825,22 @@ std::vector<pstsdk::byte> encoded_needle(const std::wstring& text)
     return raw;
 }
 
+// Occurrences anywhere in the file, free space included. This is the measure
+// that matters once the wipe has run.
+size_t count_occurrences(const std::vector<pstsdk::byte>& hay,
+                         const std::vector<pstsdk::byte>& needle)
+{
+    if(needle.empty() || hay.size() < needle.size())
+        return 0;
+
+    size_t hits = 0;
+    for(size_t i = 0; i + needle.size() <= hay.size(); ++i)
+        if(memcmp(&hay[i], &needle[0], needle.size()) == 0)
+            ++hits;
+
+    return hits;
+}
+
 // Occurrences that land inside a block the store still references. Free space is
 // deliberately excluded: real stores already carry stale plaintext there from
 // whatever the original client deleted, and an in place edit does not clear it.
@@ -1112,6 +1128,61 @@ void test_delete_attachment(const std::string& sample)
     (void)cleared;
 }
 
+// The one test that speaks to the point of the feature: after deleting an item
+// and wiping, its text is absent from the whole file, not merely from the blocks
+// the store still references. submessage.pst ships with copies of a subject in
+// space its original client freed, so this covers inherited residue too.
+template<typename T>
+void test_wipe_free_space(const std::string& sample, const std::wstring& text)
+{
+    using namespace pstsdk;
+
+    std::wstring path = copy_sample(sample, "wipe");
+    const std::vector<byte> needle = encoded_needle(text);
+    assert(count_occurrences(slurp(path), needle) > 0);
+
+    node_id victim = 0;
+    {
+        shared_db_ptr db = open_database(path);
+        std::vector<node_id> nids = all_nids(db);
+
+        for(size_t i = 0; i < nids.size() && victim == 0; ++i)
+        {
+            if(get_nid_type(nids[i]) != nid_type_message)
+                continue;
+
+            // get_subject strips the two byte prefix the raw property carries
+            message item(db->lookup_node(nids[i]));
+            if(item.has_subject() && item.get_subject() == text)
+                victim = nids[i];
+        }
+    }
+    assert(victim != 0);
+
+    ulonglong wiped = 0;
+    {
+        std::shared_ptr<file> f(new file(path, true));
+        shared_db_ptr db = open_database(f);
+        delete_message(db, victim);
+    }
+    {
+        std::shared_ptr<file> f(new file(path, true));
+        shared_db_ptr db = open_database(f);
+        wiped = wipe_free_space(db);
+    }
+    assert(wiped > 0);
+
+    // gone from the file outright, not just from what the store reads
+    assert(count_occurrences(slurp(path), needle) == 0);
+
+    shared_db_ptr db = open_database(path);
+    check_refcounts<T>(db, path);
+    db.reset();
+
+    walk_store(path);
+    std::filesystem::remove(narrow(path));
+}
+
 // Every store under test/ keeps its row matrices inline, so nothing here reaches
 // the subnode path, which is the one a real folder takes past a few dozen
 // messages. Point PSTSDK_TEST_CORPUS at a directory of real stores to cover it:
@@ -1163,7 +1234,21 @@ void drain_store(const std::string& source)
         }
     }
 
+    ulonglong wiped = 0;
+    {
+        std::shared_ptr<file> f(new file(path, true));
+        shared_db_ptr db = open_database(f);
+        wiped = wipe_free_space(db);
+    }
+    {
+        shared_db_ptr db = open_database(path);
+        check_refcounts<T>(db, path);
+        db.reset();
+        walk_store(path);
+    }
+
     assert(deleted > 0);
+    std::wcout << L"  wiped " << wiped << L" bytes after draining" << std::endl;
     std::wcout << L"  drained " << deleted << L" messages from "
                << widen(source) << std::endl;
 
@@ -1331,6 +1416,9 @@ void test_delete()
     test_delete_folder<pstsdk::ulonglong>("submessage.pst");
 
     test_delete_attachment<pstsdk::ulonglong>("submessage.pst");
+
+    test_wipe_free_space<pstsdk::ulonglong>(
+        "submessage.pst", L"This is a message which has an embedded message attached");
 
     test_corpus();
 }

--- a/test/disktest.cpp
+++ b/test/disktest.cpp
@@ -123,7 +123,7 @@ void test_crypt()
     }
 }
 
-void test_disk()
+void test_disk() 
 {
     using namespace std;
     using namespace pstsdk;

--- a/test/disktest.cpp
+++ b/test/disktest.cpp
@@ -86,10 +86,50 @@ void test_disk_structures(pstsdk::file& file)
     test_page<T>(file, pheader->root_info.brefBBT, pheader->bCryptMethod);
 }
 
-void test_disk() 
+// A write path has to re-encode, and permute(..., true) is only an inverse of the
+// decode direction the reader already uses if table1 and table3 invert each other.
+// cyclic() takes no direction argument because it conjugates table2, which is an
+// involution, making the whole transform self-inverse.
+// [MS-PST] 5.1
+void test_crypt()
+{
+    using namespace pstsdk;
+    using namespace pstsdk::disk;
+
+    for(int i = 0; i < 256; ++i)
+    {
+        assert(table3[table1[i]] == i);
+        assert(table1[table3[i]] == i);
+        assert(table2[table2[i]] == i);
+    }
+
+    std::vector<byte> plain(1024);
+    for(size_t i = 0; i < plain.size(); ++i)
+        plain[i] = (byte)i;
+
+    std::vector<byte> buffer(plain);
+    permute(&buffer[0], (pstsdk::ulong)buffer.size(), true);
+    assert(buffer != plain);
+    permute(&buffer[0], (pstsdk::ulong)buffer.size(), false);
+    assert(buffer == plain);
+
+    const pstsdk::ulong keys[] = { 0, 1, 0x1234, 0xdeadbeef, 0xffffffff };
+    for(size_t i = 0; i < sizeof(keys) / sizeof(keys[0]); ++i)
+    {
+        buffer = plain;
+        cyclic(&buffer[0], (pstsdk::ulong)buffer.size(), keys[i]);
+        cyclic(&buffer[0], (pstsdk::ulong)buffer.size(), keys[i]);
+        assert(buffer == plain);
+    }
+}
+
+void test_disk()
 {
     using namespace std;
     using namespace pstsdk;
+
+    test_crypt();
+
     file uni(L"test_unicode.pst");
     file ansi(L"test_ansi.pst");
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -31,8 +31,10 @@ int main()
     catch(exception& e)
     {
         cout << "*****" << typeid(e).name() << "*****" << endl;
-        cout << e.what();
-        throw;
+        cout << e.what() << endl;
+        // returning beats rethrowing: an abort here pops Windows Error Reporting,
+        // which blocks a CI runner until it is killed
+        return 1;
     }
 
 #ifdef _MSC_VER

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -25,6 +25,8 @@ int main()
         // test_highlevel();
         cout << "test_pstlevel();" << endl;
         test_pstlevel();
+        cout << "test_delete();" << endl;
+        test_delete();
     } 
     catch(exception& e)
     {

--- a/test/test.h
+++ b/test/test.h
@@ -7,6 +7,7 @@ void test_db();
 void test_disk();
 void test_highlevel();
 void test_pstlevel();
+void test_delete();
 
 #endif
 


### PR DESCRIPTION
Deletes messages, attachments and folders from a PST in place, and wipes the free
space left behind. The caller copies a store and we edit the copy: every write goes
back to the address it came from at the same size or smaller, so there is no
allocator and no file layout logic.

```cpp
auto f = std::make_shared<pstsdk::file>(L"copy.pst", true);
auto db = pstsdk::open_database(f);
pstsdk::delete_message(db, nid);
pstsdk::delete_attachment(db, message_nid, attachment_nid);
pstsdk::delete_folder(db, nid);
pstsdk::wipe_free_space(db);
```

Deleted content is zeroed, not just unlinked. `wipe_free_space` also clears text the
original client left in free space years earlier, which a delete cannot reach.
`commit()` invalidates the AMaps so the client rebuilds them.

- `pstsdk/ndb/writer.h` -- blocks, BTree pages, subnode trees, node release, free space
- `pstsdk/ltp/writer.h` -- heaps, BTHs, table rows, inline properties
- `pstsdk/pst/delete.h` -- the four entry points above

## Test plan

- [x] `ninja -C build test` covers both formats, exhaustive over every node, row,
      message and folder in the sample stores
- [x] `PSTSDK_TEST_CORPUS=<dir> ninja -C build test` strips every attachment, drains
      every message, then wipes, checking the reference graph throughout
- [x] Enron corpus: 14723 messages and 7413 attachments across 19 stores drained to
      empty and wiped, 0 orphaned and 0 miscounted throughout
- [x] A pruned store opens in Outlook for Mac, GoldFynch and duckdb-pst

## Notes

`sizeof(disk::bth_leaf_entry<row_id, ushort>)` is 8 because the struct sits outside
the `pack(2)` region covering `bth_nonleaf_entry`, while an ANSI row index steps 6.
`bth_leaf_node` divides by that same sizeof, so `basic_table<ushort>::lookup_row` is
wrong today on ANSI stores. Nothing calls it, so it is latent. This branch takes its
strides from the BTH header instead; the reader fix belongs in its own change.

Not covered: subnode row matrices on ANSI, since all 171 corpus stores are Unicode
and the samples are too small to need one; the search folder sweep, since every search contents
table across those 19 stores has zero rows, though its row removal is the same
primitive the message deletes exercise; and `fAMapValid = 0` against a client
that writes rather than reads.
