### PR TITLE
fix #3: convert via UTF-32LE, WCHAR_T follows LC_CTYPE on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,23 @@ endif()
 # Use iconv if we have it.  This is required on non-Win32 platforms,
 # because we don't necessarily know the encoding of wchar_t.
 if (NOT MSVC)
+  # macOS ships an iconv whose UTF-16LE decoder is broken, and FindIconv picks
+  # it up before homebrew's GNU build. duckdb-pst hit the same thing, see
+  # intellekthq/duckdb-pst e766d3a.
+  if(APPLE)
+    execute_process(COMMAND brew --prefix libiconv
+                    OUTPUT_VARIABLE GNU_ICONV_PREFIX
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    ERROR_QUIET)
+    if(GNU_ICONV_PREFIX AND EXISTS "${GNU_ICONV_PREFIX}/lib/libiconv.dylib")
+      set(Iconv_INCLUDE_DIR "${GNU_ICONV_PREFIX}/include")
+      set(Iconv_LIBRARY "${GNU_ICONV_PREFIX}/lib/libiconv.dylib")
+      message(STATUS "Using GNU iconv from ${GNU_ICONV_PREFIX}")
+    else()
+      message(WARNING "GNU iconv not found, UTF-16LE decoding will be wrong")
+    endif()
+  endif()
+
   find_package(Iconv REQUIRED)
 endif()
 

--- a/pstsdk/util/util.h
+++ b/pstsdk/util/util.h
@@ -12,6 +12,8 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
+#include <cerrno>
 #include <time.h>
 #include <memory>
 #include <string>
@@ -309,9 +311,27 @@ inline std::wstring pstsdk::bytes_to_wstring(const std::vector<byte> &bytes)
     char *outbuf = reinterpret_cast<char *>(&out[0]);
     size_t outbytesleft = out.size() * sizeof(wchar_t);
     size_t result = ::iconv(cd, const_cast<char **>(&inbuf), &inbytesleft, &outbuf, &outbytesleft);
+    const int err = errno;
     ::iconv_close(cd);
     if(result == (size_t)(-1) || inbytesleft > 0 || outbytesleft % sizeof(wchar_t) != 0)
-        throw std::runtime_error("Failed to convert from UTF-16LE to wstring");
+    {
+        // TEMPORARY, for issue #3: macos fails here and linux does not, so say
+        // which bytes and which errno rather than guessing
+        std::string hex;
+        for(size_t i = 0; i < bytes.size() && i < 64; ++i)
+        {
+            char b[4];
+            snprintf(b, sizeof(b), "%02x ", bytes[i]);
+            hex += b;
+        }
+        throw std::runtime_error("Failed to convert from UTF-16LE to wstring"
+            " (errno=" + std::to_string(err) + " " + std::strerror(err) +
+            ", in=" + std::to_string(bytes.size()) +
+            ", inleft=" + std::to_string(inbytesleft) +
+            ", outleft=" + std::to_string(outbytesleft) +
+            ", sizeof(wchar_t)=" + std::to_string(sizeof(wchar_t)) +
+            ", bytes=" + hex + ")");
+    }
 
     out.resize(out.size() - (outbytesleft / sizeof(wchar_t)));
     return out;

--- a/pstsdk/util/util.h
+++ b/pstsdk/util/util.h
@@ -322,24 +322,10 @@ inline std::wstring pstsdk::bytes_to_wstring(const std::vector<byte> &bytes)
     const int err = errno;
     ::iconv_close(cd);
     if(result == (size_t)(-1) || inbytesleft > 0 || outbytesleft % sizeof(wchar_t) != 0)
-    {
-        // TEMPORARY, for issue #3: macos fails here and linux does not, so say
-        // which bytes and which errno rather than guessing
-        std::string hex;
-        for(size_t i = 0; i < bytes.size() && i < 64; ++i)
-        {
-            char b[4];
-            snprintf(b, sizeof(b), "%02x ", bytes[i]);
-            hex += b;
-        }
-        throw std::runtime_error("Failed to convert from UTF-16LE to wstring"
-            " (errno=" + std::to_string(err) + " " + std::strerror(err) +
-            ", in=" + std::to_string(bytes.size()) +
-            ", inleft=" + std::to_string(inbytesleft) +
-            ", outleft=" + std::to_string(outbytesleft) +
-            ", sizeof(wchar_t)=" + std::to_string(sizeof(wchar_t)) +
-            ", bytes=" + hex + ")");
-    }
+        throw std::runtime_error("Failed to convert from UTF-16LE to wstring: "
+            + std::string(std::strerror(err)) + ", "
+            + std::to_string(inbytesleft) + " of "
+            + std::to_string(bytes.size()) + " bytes left");
 
     out.resize(out.size() - (outbytesleft / sizeof(wchar_t)));
     return out;

--- a/pstsdk/util/util.h
+++ b/pstsdk/util/util.h
@@ -290,6 +290,14 @@ inline std::string pstsdk::bytes_to_string(const std::vector<byte> &bytes)
 // big wchar_t really is, or what encoding it uses.
 #include <iconv.h>
 
+// Not "WCHAR_T": libiconv implements that through the platform's mbrtowc, so
+// on macOS it follows LC_CTYPE and rejects anything outside it. Under the C
+// locale a right single quote comes back EILSEQ. glibc hardwires WCHAR_T to
+// UCS-4 and never showed this. Both libraries take a fixed width name, and
+// every platform reaching this branch is little endian with a 4 byte wchar_t.
+static_assert(sizeof(wchar_t) == 4, "expected a 4 byte wchar_t off Windows");
+#define PSTSDK_WCHAR_ENCODING "UTF-32LE"
+
 inline std::wstring pstsdk::bytes_to_wstring(const std::vector<byte> &bytes)
 {
     if(bytes.size() == 0)
@@ -300,7 +308,7 @@ inline std::wstring pstsdk::bytes_to_wstring(const std::vector<byte> &bytes)
         throw std::runtime_error("Cannot interpret odd number of bytes as UTF-16LE");
     std::wstring out(bytes.size() / 2, L'\0');
 
-    iconv_t cd(::iconv_open("WCHAR_T", "UTF-16LE"));
+    iconv_t cd(::iconv_open(PSTSDK_WCHAR_ENCODING, "UTF-16LE"));
     if(cd == (iconv_t)(-1)) {
         perror("bytes_to_wstring");
         throw std::runtime_error("Unable to convert from UTF-16LE to wstring");
@@ -379,7 +387,7 @@ inline std::vector<pstsdk::byte> pstsdk::wstring_to_bytes(const std::wstring &ws
     // Up to 4 bytes per character if all codepoints are surrogate pairs.
     std::vector<byte> out(wstr.size() * 4);
 
-    iconv_t cd(::iconv_open("UTF-16LE", "WCHAR_T"));
+    iconv_t cd(::iconv_open("UTF-16LE", PSTSDK_WCHAR_ENCODING));
     if(cd == (iconv_t)(-1)) {
         perror("wstring_to_bytes");
         throw std::runtime_error("Unable to convert from wstring to UTF-16LE");

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -20,9 +20,8 @@ int main()
         test_disk();
         cout << "test_db();" << endl;
         test_db();
-        // TODO https://github.com/intellekthq/microsoft-pst-sdk/issues/3
-        // cout << "test_highlevel();" << endl;
-        // test_highlevel();
+        cout << "test_highlevel();" << endl;
+        test_highlevel();
         cout << "test_pstlevel();" << endl;
         test_pstlevel();
         cout << "test_delete();" << endl;


### PR DESCRIPTION
Fixes #3.

`test_highlevel()` was commented out in `9c61b78`, and `ci.yml` arrived in `838cc8d` with it already disabled, so no platform ever ran it. Re-enabling it reproduced the failure on macOS immediately, while ubuntu and windows passed.

## Root cause

`bytes_to_wstring` asked iconv for `WCHAR_T`. libiconv implements that target through the platform's `mbrtowc`, so it follows `LC_CTYPE`. A CI runner sets no locale, so on macOS wchar_t conversion is ASCII only and anything above U+007F comes back `EILSEQ`. glibc hardwires `WCHAR_T` to UCS-4 and ignores the locale, which is why Linux never showed it.

The trigger is one character. `sample1.pst` node `0x200024`, prop `0x1000` (`PR_BODY`), is the only non-ASCII wstring prop in any of the five fixtures:

```
errno=92 Illegal byte sequence, in=158, inleft=102, sizeof(wchar_t)=4
bytes=... 61 00 74 00 74 00 61 00 63 00 68 00 6d 00 65 00 6e 00 74 00 2e 00 20 00 49 00 74 00 19 20 ...
```

That is `...attachment. It` followed by `19 20`, little endian U+2019. iconv consumed 56 of 158 bytes and stopped on the right single quote.

It escapes because `highlevel.cpp:226` reads every `prop_type_wstring` prop outside any try block, unlike the mv-prop loop above it.

## Fix

Name a fixed width encoding both libraries implement natively, rather than one that defers to the locale:

```c
static_assert(sizeof(wchar_t) == 4, "expected a 4 byte wchar_t off Windows");
#define PSTSDK_WCHAR_ENCODING "UTF-32LE"
```

Applied to both conversion directions. The Windows branch uses `WideCharToMultiByte` and never reached this code.

Also links GNU iconv on macOS rather than the system copy. That is not what fixed this, and I confirmed macOS still failed with GNU iconv linked, but intellekthq/duckdb-pst e766d3a found a real UTF-16LE decoder defect in the system build, so the SDK should match.

## What was ruled out

- Reproduction on GCC 15.2.1, clang 21.1.8, valgrind, ASan and UBSan, and `LC_ALL` of C, POSIX, C.UTF-8 and ISO-8859-1. All clean, including at `9c61b78` itself.
- The `-Wincompatible-ms-struct` warnings. All 12 structs that trigger them add no members to their base, so MS and Itanium layouts coincide.
- `bytes_to_string` in #4, which is inside `#if defined(_WIN32)`.

## Unrelated bug found on the way

`heap.h:485` uses `sizeof(disk::bth_leaf_entry<K,V>)` as both the entry count divisor and the array stride:

```
bth_leaf_entry<prop_id, prop_entry> sizeof=8 (on-disk 8)  ok
bth_leaf_entry<row_id, ushort>      sizeof=8 (on-disk 6)  MISMATCH
```

An ANSI table's row index is the mismatched one (`table.h:491`, `basic_table<ushort>`), so the count is short by 25% and entries are read at the wrong offset. It is the only instantiation with no `static_assert`. `writer.h:394-399` already takes strides from the BTH header to avoid exactly this. Left alone here.
